### PR TITLE
Tweak some mappings to use Leader instead of '\'

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1349,7 +1349,7 @@ xmap <silent> <C-T> <Plug>VisualSwap
 let VCSCommandMapPrefix = '<Leader>s'
 
 " When doing diff, force two-window layout with old on left.
-nmap <silent> \sv <C-W>o<Plug>VCSVimDiff<C-W>H<C-W>w
+nmap <silent> <Leader>sv <C-W>o<Plug>VCSVimDiff<C-W>H<C-W>w
 
 " -------------------------------------------------------------
 " winmanager


### PR DESCRIPTION
I thought I'd experiment with changing the leader, and found that there were a couple mappings that had a hardcoded '\'.  This changes them to use <Leader> instead.

FWIW, on my keyboard, ',' is a more comfortable reach... and is playing out nicely as a leader.  I'm not sure if changing things this way breaks something.  The Command-T bits work, and I tried the VCSVimDiff shortcut and that works too.  That's on Vim 7.3.

Again, if it doesn't work for you, feel free to close the request.
