### PR TITLE
Ignore the actual ruby command-t extension, and the spell folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 ruby/command-t/Makefile
 ruby/command-t/*.log
+ruby/command-t/ext.bundle
+spell
 *.o
 *.so
 *.pyc


### PR DESCRIPTION
I've been meaning to do this for a while.  I have some local additions for the dictionary, and the Ruby command-t extension always shows up.  I could ignore the latter with a change to my git configuration, but I figured I'd add it just in case.
