### PR TITLE
Set the tabstops and shift width to 2 for Clojure.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1809,6 +1809,7 @@ command! SetupCpp call SetupCpp()
 " -------------------------------------------------------------
 function! SetupClojure()
     call SetupSource()
+    setlocal ts=2 sts=2 sw=2
 endfunction
 command! SetupClojure call SetupClojure()
 


### PR DESCRIPTION
When using leiningen plugins that create skeleton or template projects,
the indentation is always done using 2 spaces.  It's simply too much to
constantly fix them.  It appears to be the general style used by most
folks.

Like always, you don't need to accept this change.  FWIW, constantly dealing with code that's spaced differently has been a problem... so I'm caving in. :-)
