### PR TITLE
Set the textwidth for svn commits, and turn on spell checking too.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1976,6 +1976,12 @@ augroup local_vimrc
     " Do the same for Subversion.
     autocmd BufReadPost svn-commit.tmp exe "normal! gg"
 
+    " Set the text width for commit messages in Subversion.  It turns out
+    " that Vim has a file type mapping for Subversion commits: svn.  Set it
+    " to the same width as Git commit messages, 72.  Turn on spell-checking
+    " as well.
+    autocmd FileType svn setlocal tw=72 spell
+
     " Use tabs in gitconfig and .gitconfig.
     autocmd FileType gitconfig setlocal noexpandtab
     autocmd FileType .gitconfig setlocal noexpandtab


### PR DESCRIPTION
Hey Mike, this fixes that textwidth issue I mentioned the other day.  The only catch is that I set textwidth to 72, matching what's used in Git since I figured they had a good reason for doing so (email quoting, formatting of commit messages in commit emails, etc.).

Also, I turned on spell checking for SVN commits, since it's proven to be helpful with all the git commits I've been making.
