### PR TITLE
Use backupcopy=yes on crontab files.

### DIFF
--- a/filetype.vim
+++ b/filetype.vim
@@ -17,4 +17,8 @@ augroup filetypedetect
     au BufNewFile,BufRead *.{rest} setf rst
     au BufNewFile,BufRead bash-fc-* unlet g:is_kornshell | let g:is_bash=1 | setf sh | setl nospell | setl tw=0 | Highlight no*
     au BufNewFile,BufRead *.cljs setf clojure
+
+    " Use the copy and overwrite mechanism on crontab files, otherwise crontab
+    " may not see the changes we make.
+    au FileType crontab setl backupcopy=yes
 augroup END


### PR DESCRIPTION
Any other style has the potential to have crontab miss your changes.
This seems especially true under Mac OS X.
