### PR TITLE
Make the Gundo window close when a selection is made.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1358,6 +1358,7 @@ let Grep_Skip_Files = '*.bak *~ .*.swp tags *.opt *.ncb *.plg ' .
 " -------------------------------------------------------------
 
 nnoremap <Leader><Leader>u  :GundoToggle<CR>
+let g:gundo_close_on_revert = 1
 
 " -------------------------------------------------------------
 " lookupfile


### PR DESCRIPTION
I may have mentioned this is an email to you, but I've found that I don't want the Gundo window sitting there after selecting an entry.  Much better for it to go away and give me my screen real estate back.  Thought you might like the same. :-)
