### PR TITLE
Make CtrlPTag center the tag in the window.

### DIFF
--- a/bundle/ctrlp.vim/autoload/ctrlp/tag.vim
+++ b/bundle/ctrlp.vim/autoload/ctrlp/tag.vim
@@ -108,6 +108,7 @@ fu! ctrlp#tag#accept(mode, str)
 	el
 		exe cmd tg
 	en
+	sil! norm! zvzz
 	cal ctrlp#setlcdir()
 endf
 

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -408,8 +408,22 @@ Local customizations:
 Version 2012-12-21 (675faa77) from https://github.com/kien/ctrlp.vim
 
 Installation:
-- Follow bundle installation instructions (|bundle_installation|).
+- Follow bundle installation instructions (|bundle_installation|), with one
+  exception.  You need to apply the following patch to allow centering of
+  the selected tag: >
 
+  diff --git a/bundle/ctrlp.vim/autoload/ctrlp/tag.vim b/bundle/ctrlp.vim/autoload/ctrlp/tag.vim
+  index 83921a5..2288681 100644
+  --- a/bundle/ctrlp.vim/autoload/ctrlp/tag.vim
+  +++ b/bundle/ctrlp.vim/autoload/ctrlp/tag.vim
+  @@ -108,6 +108,7 @@ fu! ctrlp#tag#accept(mode, str)
+    el
+      exe cmd tg
+    en
+  +	sil! norm! zvzz
+    cal ctrlp#setlcdir()
+   endf
+<
 ------------------------------------------------------------------------------
 COLORSAMPLERPACK                                        *notes_colorsampler*
   Color schemes and theme menu


### PR DESCRIPTION
At the moment, it leaves the cursor on the tag, but it could be anywhere
in the window.  This patch puts the tag right in the center, where you
expect it.  I'm trying to this upstream, but the maintainer doesn't seem
to think it's useful when the tags file is out-of-date.  He had this to
say:

  If :tag fails, running zvzz blindly will open the folds and change
  the view of the current buffer.

I disagree though.  First, Vim searches to try and locate the tag.  I
even experimented and examined the source to make sure that it did so.
Second, if :tag fails it still moves the cursor, so it's still helpful
to see where you are.  Finally, having the cursor appear in a known
location on the screen, with an equal chance of the tag being above or
below, is a Good Thing even if the tags are off a bit.
