### PR TITLE
Allow users to disable the use of Powerline.

### DIFF
--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -1142,6 +1142,12 @@ font and use it: >
         endif
     endif
 <
+
+If you don't want to use Powerline, you can add the following to your
+user/$VIMUSER-before.vim: >
+
+    let g:Powerline_loaded = 0
+<
 Version 2012-08-17 from https://github.com/Lokaltog/vim-powerline
 
 Installation:

--- a/user/jszakmeister-after.vim
+++ b/user/jszakmeister-after.vim
@@ -160,17 +160,19 @@ endif
 
 " Powerline
 
-" Add back in a few segments...
-call Pl#Theme#InsertSegment('mode_indicator', 'after', 'paste_indicator')
-call Pl#Theme#InsertSegment('filetype', 'before', 'scrollpercent')
-call Pl#Theme#InsertSegment('fileformat', 'before', 'filetype')
+if exists("g:Powerline_loaded") && g:Powerline_loaded
+    " Add back in a few segments...
+    call Pl#Theme#InsertSegment('mode_indicator', 'after', 'paste_indicator')
+    call Pl#Theme#InsertSegment('filetype', 'before', 'scrollpercent')
+    call Pl#Theme#InsertSegment('fileformat', 'before', 'filetype')
 
-call Pl#Theme#InsertSegment('ws_marker', 'after', 'lineinfo')
+    call Pl#Theme#InsertSegment('ws_marker', 'after', 'lineinfo')
 
-if !has("gui_running")
-    let g:Powerline_symbols_override = {
-        \ 'BRANCH': [0x2442],
-        \ }
+    if !has("gui_running")
+        let g:Powerline_symbols_override = {
+            \ 'BRANCH': [0x2442],
+            \ }
+    endif
 endif
 
 function! ShowHighlightGroup()

--- a/vimrc
+++ b/vimrc
@@ -2247,23 +2247,27 @@ set laststatus=2
 " Powerline
 " =============================================================
 
-" Remove segments that are redundant (like "mode_indicator") or
-" which are essentially static indicators that don't warrant taking
-" up room.
-call Pl#Theme#RemoveSegment('mode_indicator')
-call Pl#Theme#RemoveSegment('fileformat')
-call Pl#Theme#RemoveSegment('fileencoding')
-call Pl#Theme#RemoveSegment('filetype')
+" Allow user's to opt-out of using Powerline.
+if exists("g:Powerline_loaded") && g:Powerline_loaded
+    " Remove segments that are redundant (like "mode_indicator") or
+    " which are essentially static indicators that don't warrant taking
+    " up room.
+    call Pl#Theme#RemoveSegment('mode_indicator')
+    call Pl#Theme#RemoveSegment('fileformat')
+    call Pl#Theme#RemoveSegment('fileencoding')
+    call Pl#Theme#RemoveSegment('filetype')
 
-" Move 'fileinfo' and 'syntastic:errors' after the Truncate() to keep the
-" basename of the file visible as long as possible.  If we start using
-" the Syntastic plugin, this may have to be adjusted so that syntastic
-" output is truncated first.  This preserves the order found in Powerline's
-" autoload/Powerline/Themes/default.vim file.
-call Pl#Theme#RemoveSegment('fileinfo')
-call Pl#Theme#InsertSegment('fileinfo', 'before', 'tagbar:currenttag')
-call Pl#Theme#RemoveSegment('syntastic:errors')
-call Pl#Theme#InsertSegment('syntastic:errors', 'before', 'tagbar:currenttag')
+    " Move 'fileinfo' and 'syntastic:errors' after the Truncate() to keep the
+    " basename of the file visible as long as possible.  If we start using
+    " the Syntastic plugin, this may have to be adjusted so that syntastic
+    " output is truncated first.  This preserves the order found in Powerline's
+    " autoload/Powerline/Themes/default.vim file.
+    call Pl#Theme#RemoveSegment('fileinfo')
+    call Pl#Theme#InsertSegment('fileinfo', 'before', 'tagbar:currenttag')
+    call Pl#Theme#RemoveSegment('syntastic:errors')
+    call Pl#Theme#InsertSegment('syntastic:errors', 'before',
+                \               'tagbar:currenttag')
+endif
 
 " =============================================================
 " Color schemes


### PR DESCRIPTION
While I think it's a great default, it may not be for everyone.  So
provide a way for users to opt-out of having it, if they prefer the
default status line.

I updated my configuration as well, since I like being able to debug
things without Powerline in the mix.
