### PR TITLE
Add missing command for SetupKernelSource.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -2048,6 +2048,7 @@ function! SetupKernelSource()
     "   t - autowrap using textwidth,
     setlocal formatoptions=croqlnt
 endfunction
+command! SetupKernelSource call SetupKernelSource()
 
 " Source support for :Man command.
 runtime ftplugin/man.vim


### PR DESCRIPTION
This is mainly to follow the agreed upon convention of having commands for all our setup functions.
