### PR TITLE
Set iskeyword while editing help files.

### DIFF
--- a/after/ftplugin/help.vim
+++ b/after/ftplugin/help.vim
@@ -1,0 +1,1 @@
+SetupHelp

--- a/vimrc
+++ b/vimrc
@@ -2108,6 +2108,16 @@ function! SetupMake()
 endfunction
 command! SetupMake call SetupMake()
 
+" -------------------------------------------------------------
+" Setup for help files.
+" -------------------------------------------------------------
+function! SetupHelp()
+    " This helps make it easier to jump to tags while editing help files,
+    " since a number of tags contain a hyphen.
+    setlocal iskeyword=!-~,^*,^\|,^\",192-255
+endfunction
+command! SetupHelp call SetupHelp()
+
 " Source support for :Man command.
 runtime ftplugin/man.vim
 


### PR DESCRIPTION
It got frustrating that it wasn't easy to test links to other
documentation because iskeyword was not set the same way as when you are
viewing help files via :help.  This sets iskeyword so that it matches
how it's set while viewing help so that jumping to links like
'textobj-indent.txt' work correctly.
