### PR TITLE
Fix tagbar bug

### DIFF
--- a/bundle/tagbar/autoload/tagbar.vim
+++ b/bundle/tagbar/autoload/tagbar.vim
@@ -3056,6 +3056,7 @@ function! s:AutoUpdate(fname, force) abort
     " Don't do anything if the file isn't supported
     if !s:IsValidFile(a:fname, sftype)
         call s:LogDebugMessage('Not a valid file, stopping processing')
+        call s:known_files.setCurrent({})
         return
     endif
 

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -1394,6 +1394,20 @@ Version 2012-11-22 (feebffcd) from https://github.com/majutsushi/tagbar
 
 Installation:
 - Follow bundle installation instructions (|bundle_installation|).
+- Add the following patch to fix an issue with current tag showing up in
+  unsupported files: >
+
+  diff --git a/bundle/tagbar/autoload/tagbar.vim b/bundle/tagbar/autoload/tagbar.vim
+  index 7edc25d..99464b7 100644
+  --- a/bundle/tagbar/autoload/tagbar.vim
+  +++ b/bundle/tagbar/autoload/tagbar.vim
+  @@ -3056,6 +3056,7 @@ function! s:AutoUpdate(fname, force) abort
+       " Don't do anything if the file isn't supported
+       if !s:IsValidFile(a:fname, sftype)
+           call s:LogDebugMessage('Not a valid file, stopping processing')
+  +        call s:known_files.setCurrent({})
+           return
+       endif
 
 Requires ctags.exe to be in the path.  Generally this comes with Linux
 distributions.  Compiled binaries may be found at


### PR DESCRIPTION
I filed a bug report upstream, but it appears that the maintainer has been down and out for a few months.  I don't believe he's going to get to it any time soon.  In the meantime, let's patch the bug here.

You might enjoy knowing that I discovered this when editing a reStructuredText file, and I hit a line and saw `die` appear in the status line.  It turns out the bug caused it to look up tags on the file I was just editing, which happened to be a script.  And the line I was on would have been in the `die` function in the script.  I thought Vim was trying to tell me something for a minute. :-)
