### PR TITLE
Recognize svn-prop.tmp files as the svn filetype.

### DIFF
--- a/filetype.vim
+++ b/filetype.vim
@@ -17,6 +17,7 @@ augroup filetypedetect
     au BufNewFile,BufRead *.rest setfiletype rst
     au BufNewFile,BufRead bash-fc-* SetupBashFixcommand
     au BufNewFile,BufRead *.cljs setfiletype clojure
+    au BufNewFile,BufRead svn-prop*.tmp setfiletype svn
 
     " Setup Git-related filetypes.
     au BufNewFile,BufRead *.git/MERGE_MSG setfiletype gitcommit


### PR DESCRIPTION
While editing a svn prop the other day, I noticed that it wasn't recognized as an svn filetype.  Let's fix that.
