### PR TITLE
Add vim-togglelist.

### DIFF
--- a/bundle/vim-togglelist/README.md
+++ b/bundle/vim-togglelist/README.md
@@ -1,0 +1,30 @@
+# togglelist.vim
+
+A simple plugin for vim that allows you to bind a key to toggle the `Location List` and the `Quickfix List`. This plugin is currently in early development and there aren't many things besides a few options I imagine adding. Feel free to submit patches.
+
+## Installation
+
+### Basic Brute-Force Install
+
+Copy `togglelist.vim` to your `~/.vim/plugin` directory.
+
+### Pathogen
+
+Checkout the github repository to the [Pathogen](https://github.com/tpope/vim-pathogen) directory.
+
+    cd ~/.vim/bundle
+    git clone https://github.com/milkypostman/vim-togglelist.git
+
+
+## Mappings
+
+The default mappings are:
+
+    nmap <script> <silent> <leader>l :call ToggleLocationList()<CR>
+    nmap <script> <silent> <leader>q :call ToggleQuickfixList()<CR>
+
+You can prevent these mappings by setting `g:toggle_list_no_mappings` in your `.vimrc` and then remap them if you want--both `ToggleLocationList` and `ToggleQuickfixList` are global functions. I imagine the names of the functions are self-explanatory.
+
+After opening or closing either list, the previous window is restored so you can still use `<C-w>p`.
+
+

--- a/bundle/vim-togglelist/plugin/togglelist.vim
+++ b/bundle/vim-togglelist/plugin/togglelist.vim
@@ -1,0 +1,79 @@
+" toggle list plugin
+"
+" Donald Ephraim Curtis (2011)
+"
+" boom
+"
+" This plugin allows you to use \l and \q to toggle the location list and
+" quickfix list (respectively).
+"
+"
+
+if exists("g:loaded_toggle_list")
+  finish
+endif
+
+function! s:GetBufferList() 
+  redir =>buflist 
+  silent! ls 
+  redir END 
+  return buflist 
+endfunction
+
+function! ToggleLocationList()
+  let curbufnr = winbufnr(0)
+  for bufnum in map(filter(split(s:GetBufferList(), '\n'), 'v:val =~ "Location List"'), 'str2nr(matchstr(v:val, "\\d\\+"))')
+    if curbufnr == bufnum
+      lclose
+      return
+    endif
+  endfor
+
+  let winnr = winnr()
+  let prevwinnr = winnr("#")
+
+  let nextbufnr = winbufnr(winnr + 1)
+  try
+    lopen
+  catch /E776/
+      echohl ErrorMsg 
+      echo "Location List is Empty."
+      echohl None
+      return
+  endtry
+  if winbufnr(0) == nextbufnr
+    lclose
+    if prevwinnr > winnr
+      let prevwinnr-=1
+    endif
+  else
+    if prevwinnr > winnr
+      let prevwinnr+=1
+    endif
+  endif
+  " restore previous window
+  exec prevwinnr."wincmd w"
+  exec winnr."wincmd w"
+endfunction
+
+function! ToggleQuickfixList()
+  for bufnum in map(filter(split(s:GetBufferList(), '\n'), 'v:val =~ "Quickfix List"'), 'str2nr(matchstr(v:val, "\\d\\+"))') 
+    if bufwinnr(bufnum) != -1
+      cclose
+      return
+    endif
+  endfor
+  let winnr = winnr()
+  copen
+  if winnr() != winnr
+    wincmd p
+  endif
+endfunction
+
+if !exists("g:toggle_list_no_mappings")
+    nmap <script> <silent> <leader>l :call ToggleLocationList()<CR>
+    nmap <script> <silent> <leader>q :call ToggleQuickfixList()<CR>
+endif
+
+
+

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -54,6 +54,7 @@
     TextObj-Indent - Indentation-based text objects     |notes_textobj-indent|
     TextObj-User - Supports user-defined text objects   |notes_textobj-user|
     ToggleCursor - Changes cursor shape in terminal     |notes_togglecursor|
+    ToggleList - Toggles quickfix and location list     |notes_togglelist|
     UltiSnips - Support for inserting snippets of text  |notes_ultisnips|
     vcscommand - Version Control System integration     |notes_vcscommand|
     VimBall - Vim "package manager"                     |notes_vimball|
@@ -1736,6 +1737,22 @@ need version 1.7 or better.
 
 Version 0.1.0 (34373bd2) from
 git://github.com/jszakmeister/vim-togglecursor.git
+
+Installation:
+- Follow bundle installation instructions (|bundle_installation|).
+
+------------------------------------------------------------------------------
+TOGGLELIST                                              *notes_togglelist*
+  Toggles quickfix and location list
+
+Local customizations:
+
+- Prevented default mappings.
+- Mapped ToggleQuickfixList to <C-Q><C-Q>.
+- Mapped ToggleLocationList to <C-Q><C-L>.
+
+Version 2013-02-07 (860defed) from
+git://github.com/milkypostman/vim-togglelist.git
 
 Installation:
 - Follow bundle installation instructions (|bundle_installation|).

--- a/doc/tags
+++ b/doc/tags
@@ -360,6 +360,7 @@ notes_textobj-indent	notes.txt	/*notes_textobj-indent*
 notes_textobj-user	notes.txt	/*notes_textobj-user*
 notes_tips	notes.txt	/*notes_tips*
 notes_togglecursor	notes.txt	/*notes_togglecursor*
+notes_togglelist	notes.txt	/*notes_togglelist*
 notes_ultisnips	notes.txt	/*notes_ultisnips*
 notes_vcscommand	notes.txt	/*notes_vcscommand*
 notes_vimball	notes.txt	/*notes_vimball*

--- a/vimrc
+++ b/vimrc
@@ -1200,17 +1200,6 @@ command! -bar L4 call s:L(4)
 " Make 5-column-wide layout.
 command! -bar L5 call s:L(5)
 
-" Toggle quickfix window.
-function! QuickFixWinToggle()
-    if s:quickFixBufNum() > 0
-        cclose
-    else
-        botright copen
-    endif
-endfunction
-nnoremap <silent> <C-Q><C-Q> :call QuickFixWinToggle()<CR>
-command! -bar QuickFixWinToggle :call QuickFixWinToggle()
-
 " Like windo but restore the current window.
 function! WinDo(command)
     let currwin=winnr()
@@ -1622,6 +1611,17 @@ function! CreateTextobjDiffLocalMappings()
     endfor
 endfunction
 
+" -------------------------------------------------------------
+" ToggleList
+" -------------------------------------------------------------
+
+let g:toggle_list_no_mappings = 1
+
+nnoremap <silent> <C-Q><C-Q> :call ToggleQuickfixList()<CR>
+command! -bar QuickFixWinToggle :call ToggleQuickfixList()
+
+nnoremap <silent> <C-Q><C-L> :call ToggleLocationList()<CR>
+command! -bar LocationListWinToggle :call ToggleLocationList()
 
 " -------------------------------------------------------------
 " UltiSnips


### PR DESCRIPTION
This replaces a custom routine for toggling the quickfix window, but
also provides the ability to toggle the location list window.

I've been trying out Syntastic, and it's really nice to have this functionality.  Since I thought it might also be useful with other plugins that use location list, I figured I'd add to the configuration.
