### PR TITLE
Remove a misplaced tag from the bufexplorer patch.

### DIFF
--- a/bundle/bufexplorer/doc/bufexplorer.txt
+++ b/bundle/bufexplorer/doc/bufexplorer.txt
@@ -167,7 +167,6 @@ To control whether to show "No Name" buffers or not, use: >
   let g:bufExplorerShowNoName=1      " Show "No Name" buffers.
 The default is to show "No Name" buffers.
 
-                                                          *g:bufExplorerSortBy*
                                                 *g:bufExplorerShowRelativePath*
 To control whether to show absolute paths or relative to the current
 directory, use: >

--- a/bundle/bufexplorer/doc/tags
+++ b/bundle/bufexplorer/doc/tags
@@ -20,7 +20,6 @@ g:bufExplorerShowRelativePath	bufexplorer.txt	/*g:bufExplorerShowRelativePath*
 g:bufExplorerShowTabBuffer	bufexplorer.txt	/*g:bufExplorerShowTabBuffer*
 g:bufExplorerShowUnlisted	bufexplorer.txt	/*g:bufExplorerShowUnlisted*
 g:bufExplorerSortBy	bufexplorer.txt	/*g:bufExplorerSortBy*
-g:bufExplorerSortBy	bufexplorer.txt	/*g:bufExplorerSortBy*
 g:bufExplorerSplitBelow	bufexplorer.txt	/*g:bufExplorerSplitBelow*
 g:bufExplorerSplitHorzSize	bufexplorer.txt	/*g:bufExplorerSplitHorzSize*
 g:bufExplorerSplitOutPathName	bufexplorer.txt	/*g:bufExplorerSplitOutPathName*

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -317,10 +317,10 @@ The following patch fixes a number of issues.  Primarily it restores
 the ability to view "No Name" buffers which was lost in version 7.3.0.
 
 diff --git a/bundle/bufexplorer/doc/bufexplorer.txt b/bundle/bufexplorer/doc/bufexplorer.txt
-index b66e823..5b51613 100644
+index b66e823..f999f69 100644
 --- a/bundle/bufexplorer/doc/bufexplorer.txt
 +++ b/bundle/bufexplorer/doc/bufexplorer.txt
-@@ -161,6 +161,13 @@ To control whether to show directories in the buffer list or not, use: >
+@@ -161,6 +161,12 @@ To control whether to show directories in the buffer list or not, use: >
    let g:bufExplorerShowDirectories=0   " Don't show directories.
  The default is to show directories.
  
@@ -330,7 +330,6 @@ index b66e823..5b51613 100644
 +  let g:bufExplorerShowNoName=1      " Show "No Name" buffers.
 +The default is to show "No Name" buffers.
 +
-+                                                          *g:bufExplorerSortBy*
                                                  *g:bufExplorerShowRelativePath*
  To control whether to show absolute paths or relative to the current
  directory, use: >

--- a/doc/tags
+++ b/doc/tags
@@ -248,7 +248,6 @@ g:alignmaps_euronumber	Align.txt	/*g:alignmaps_euronumber*
 g:alignmaps_usanumber	Align.txt	/*g:alignmaps_usanumber*
 g:bufExplorerShowNoName	notes.txt	/*g:bufExplorerShowNoName*
 g:bufExplorerShowRelativePath	notes.txt	/*g:bufExplorerShowRelativePath*
-g:bufExplorerSortBy	notes.txt	/*g:bufExplorerSortBy*
 g:loremipsum_files	loremipsum.txt	/*g:loremipsum_files*
 g:loremipsum_marker	loremipsum.txt	/*g:loremipsum_marker*
 g:loremipsum_paragraph_template	loremipsum.txt	/*g:loremipsum_paragraph_template*


### PR DESCRIPTION
It was causing :Helptags to complain since the tag appeared twice.

You may want to send an updated patch to Jeff too.
