### PR TITLE
Allow customization of the UltiSnips search path on a per-buffer basis.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1641,6 +1641,24 @@ let g:UltiSnipsExpandTrigger="<tab>"
 let g:UltiSnipsJumpForwardTrigger="<tab>"
 let g:UltiSnipsJumpBackwardTrigger="<s-tab>"
 
+function! CustomizeUltiSnipsSearchDir(entering)
+    if a:entering
+        let b:SavedUltiSnipsSnippetDirectories = g:UltiSnipsSnippetDirectories
+        if exists("b:UltiSnipsSnippetDirectories")
+            let g:UltiSnipsSnippetDirectories = b:UltiSnipsSnippetDirectories
+        endif
+    elseif exists("b:SavedUltiSnipsSnippetDirectories")
+        " Restore setting.
+        let g:UltiSnipsSnippetDirectories = b:SavedUltiSnipsSnippetDirectories
+    endif
+endfunction
+
+augroup local_ultiSnips
+    autocmd!
+    autocmd BufEnter * call CustomizeUltiSnipsSearchDir(1)
+    autocmd BufLeave * call CustomizeUltiSnipsSearchDir(0)
+augroup END
+
 " -------------------------------------------------------------
 " vis
 " -------------------------------------------------------------


### PR DESCRIPTION
After talking to SirVer about how to customize the UltiSnips search path
on a project basis, he suggested the technique implemented by this
patch.  It allows you to push something like the following into your
.lvimrc:

```
let b:UltiSnipsSnippetDirectories = ["UltiSnips", "Git"]
```

Where "Git" would contain snippets customized for working on Git in this
example.
