### PR TITLE
Use a hash (#) instead of a semicolon as the comment character.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -2800,7 +2800,7 @@ augroup local_vimrc
     autocmd BufUnload * call AutoCloseGitDiff()
 
     " Use tabs for gitconfig files.
-    autocmd FileType gitconfig setlocal noexpandtab
+    autocmd FileType gitconfig setlocal noexpandtab commentstring=#\ %s
 
     " By default, when Vim switches buffers in a window, the new buffer's
     " cursor position is scrolled to the center (as if 'zz' had been


### PR DESCRIPTION
This one was driving me a bit crazy.  Tim Pope has it set to default to a semicolon, and I find that annoying.
