### PR TITLE
Fix opening the command-line window programmatically.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -639,7 +639,6 @@ cnoremap <C-A>      <Home>
 cnoremap <C-B>      <Left>
 cnoremap <C-D>      <Del>
 cnoremap <C-F>      <Right>
-cnoremap <C-G>      <C-F>
 cnoremap <C-N>      <Down>
 cnoremap <C-P>      <Up>
 cnoremap <M-b>      <S-Left>
@@ -648,9 +647,12 @@ cnoremap <M-f>      <S-Right>
 cnoremap <C-O><C-A> <C-A>
 cnoremap <C-O><C-B> <C-B>
 cnoremap <C-O><C-D> <C-D>
-cnoremap <C-O><C-F> <C-F>
+cnoremap <C-O><C-F> <C-G>
 cnoremap <C-O><C-N> <C-N>
 cnoremap <C-O><C-P> <C-P>
+
+" Use CTRL-G to bring up the command-line window.
+let &cedit = "<C-G>"
 
 " Original meanings:
 " <C-A>   Insert all matching filenames.


### PR DESCRIPTION
It turns out that even though <C-G> and <C-O><C-F> where mapped to
<C-F>, cedit was still set to <C-F>--which was mapped to <Right>.
Therefore, any plugin that was trying to use the cedit sequence to open
the command line window, was failing.  But, it did work when the user
typed it at the command line.  Trying to change cedit to be <C-G> or
<C-O><C-F> didn't work either.  Instead of popping up the command line
window, it would simply put in a literal CTRL-F instead, even when
invoked via a plugin.

So, let's remove the <C-G> mapping, make <C-O><C-F> insert a <C-G>, and
change cedit to be <C-G>.  This not only allows our customization to
continue working, but then cedit is set correctly and plugins that use
it can pop open the command line window (such as vim-fireplace).
