### PR TITLE
Add a SetupGdb for working with .gdbinit files.

### DIFF
--- a/after/ftplugin/gdb.vim
+++ b/after/ftplugin/gdb.vim
@@ -1,0 +1,1 @@
+SetupGdb

--- a/vimrc
+++ b/vimrc
@@ -2581,6 +2581,15 @@ endfunction
 command! -bar SetupD call SetupD()
 
 " -------------------------------------------------------------
+" Setup for GDB.
+" -------------------------------------------------------------
+function! SetupGdb()
+    SetupSource
+    setlocal commentstring=#\ %s
+endfunction
+command! -bar SetupGdb call SetupGdb()
+
+" -------------------------------------------------------------
 " Setup for Git-related files (e.g., "COMMIT_EDITMSG").
 " -------------------------------------------------------------
 function! SetupGit()


### PR DESCRIPTION
This is mostly about fixing the comment string since it defaults to
using /\* ... */, which is busted in .gdbinit files.
