### PR TITLE
vimrc: add a helper for appending to the buffer local snippet dirs

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -2061,6 +2061,15 @@ function! AutoLeaveUltiSnipsBuffer()
     endif
 endfunction
 
+" Helper to be called from your .lvimrc.
+function! AppendSnippetDirs(snippetDirs)
+    if type(a:snippetDirs) == type([])
+        let b:UltiSnipsSnippetDirectories += a:snippetDirs
+    else
+        let b:UltiSnipsSnippetDirectories += [a:snippetDirs]
+    endif
+endfunction
+
 augroup local_ultiSnips
     autocmd!
     autocmd BufEnter * call AutoEnterUltiSnipsBuffer()


### PR DESCRIPTION
This is nice since it's a touch shorter than doing it yourself. :-)  Note: there's no command version of this since .lvimrc files are usually sandboxed and can't use it.
