### PR TITLE
Update to 0.1.1 of vim-togglecursor.

### DIFF
--- a/bundle/vim-togglecursor/doc/togglecursor.txt
+++ b/bundle/vim-togglecursor/doc/togglecursor.txt
@@ -81,7 +81,7 @@ interaction with the terminal, but sometimes bugs happen.  If you run into an
 environment where cursor changing is a problem, put the following into your
 vimrc to disable the plugin: >
 
-    let g:togglecursor_loaded = 0
+    let g:loaded_togglecursor = 0
 
 Once such bug appears to exist in tmux 1.6, at least under Fedora 16.  If you
 experience troubles with cursor changing under tmux, you can disable cursor

--- a/bundle/vim-togglecursor/plugin/togglecursor.vim
+++ b/bundle/vim-togglecursor/plugin/togglecursor.vim
@@ -2,7 +2,7 @@
 " File:         togglecursor.vim
 " Description:  Toggles cursor shape in the terminal
 " Maintainer:   John Szakmeister <john@szakmeister.net>
-" Version:      0.1.0
+" Version:      0.1.1
 " License:      Same license as Vim.
 " ============================================================================
 
@@ -25,7 +25,8 @@ let s:supported_terminal = ''
 
 " Check for supported terminals.
 if !has("gui_running")
-    if $TERM_PROGRAM == "iTerm.app" || $KONSOLE_DBUS_SESSION != ""
+    if $TERM_PROGRAM == "iTerm.app" || exists("$ITERM_SESSION_ID")
+                \ || $KONSOLE_DBUS_SESSION != ""
         " Konsole and  iTerm support using CursorShape.
         let s:supported_terminal = 'cursorshape'
     elseif $XTERM_VERSION != ''

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -1704,7 +1704,7 @@ Xterm is partially supported as well (it will use an underline versus a line
 cursor by default).  This technique also works with tmux, although you may
 need version 1.7 or better.
 
-Version 0.1.0 (34373bd2) from
+Version 0.1.1 (a97b8bed) from
 git://github.com/jszakmeister/vim-togglecursor.git
 
 Installation:


### PR DESCRIPTION
This updates the bundled vim-togglecursor plugin with your documentation patch and one other small addition to help detect other versions of iTerm2.
