### PR TITLE
Update to a newer version of UltiSnips.

### DIFF
--- a/bundle/ultisnips/README.rst
+++ b/bundle/ultisnips/README.rst
@@ -6,7 +6,7 @@ with the official bzr repository over at Launchpad [1] and is meant as a
 convenience for contributors. Send Pull request to this repository, not
 the automatic clone from vim-scripts.
 
-Note that we do not use the Issue tracker here one GitHub because the one on
+Note that we do not use the Issue tracker here on GitHub because the one on
 Launchpad is superior and already has a significant history. Please report
 `issues over there`_.
 

--- a/bundle/ultisnips/UltiSnips/all.snippets
+++ b/bundle/ultisnips/UltiSnips/all.snippets
@@ -67,16 +67,20 @@ def _get_comment_format():
     return commentformat
 
 
-def make_box(twidth, bwidth = None):
-   if bwidth is None:
-      bwidth = twidth + 2
-   b,m,e,i = _get_comment_format()
-   sline = b + m + bwidth*m + 2*m
-   nspaces = (bwidth - twidth)//2 
-   mlines = i + m + " " + " "*nspaces
-   mlinee = " " + " "*(bwidth-twidth-nspaces) + m
-   eline = i + 2*m + bwidth*m + m + e
-   return sline, mlines, mlinee, eline
+def make_box(twidth, bwidth=None):
+    b, m, e, i = _get_comment_format()
+    bwidth_inner = bwidth - 3 - max(len(b), len(i + e)) if bwidth else twidth + 2
+    sline = b + m + bwidth_inner * m + 2 * m
+    nspaces = (bwidth_inner - twidth) // 2
+    mlines = i + m + " " + " " * nspaces
+    mlinee = " " + " "*(bwidth_inner - twidth - nspaces) + m
+    eline = i + 2 * m + bwidth_inner * m + m + e
+    return sline, mlines, mlinee, eline
+
+def foldmarker():
+    "Return a tuple of (open fold marker, close fold marker)"
+    return vim.eval("&foldmarker").split(",")
+
 endglobal
 
 snippet box "A nice box with the current comment symbol" b
@@ -91,12 +95,27 @@ endsnippet
 
 snippet bbox "A nice box over the full width" b
 `!p
-box = make_box(len(t[1]), 71)
+width = int(vim.eval("&textwidth")) or 71
+box = make_box(len(t[1]), width)
 snip.rv = box[0] + '\n' + box[1]
 `${1:content}`!p
-box = make_box(len(t[1]), 71)
+box = make_box(len(t[1]), width)
 snip.rv = box[2] + '\n' + box[3]`
 $0
+endsnippet
+
+snippet fold "Insert a vim fold marker" !b
+`!p snip.rv = _get_comment_format()[0]` ${1:Fold description} `!p snip.rv = foldmarker()[0]`${2:1} `!p snip.rv = _get_comment_format()[2]`
+endsnippet
+
+snippet foldc "Insert a vim fold close marker" !b
+`!p snip.rv = _get_comment_format()[0]` ${2:1}`!p snip.rv = foldmarker()[1]` `!p snip.rv = _get_comment_format()[2]`
+endsnippet
+
+snippet foldp "Insert a vim fold marker pair" !b
+`!p snip.rv = _get_comment_format()[0]` ${1:Fold description} `!p snip.rv = foldmarker()[0]` `!p snip.rv = _get_comment_format()[2]`
+${2:${VISUAL:Content}}
+`!p snip.rv = _get_comment_format()[0]` `!p snip.rv = foldmarker()[1]` $1 `!p snip.rv = _get_comment_format()[2]`
 endsnippet
 
 ##########################

--- a/bundle/ultisnips/UltiSnips/bib.snippets
+++ b/bundle/ultisnips/UltiSnips/bib.snippets
@@ -1,0 +1,50 @@
+snippet online "Online resource" b
+@online{${1:name},
+	author={${2:author}},
+	title={${3:title}},
+	date={${4:date}},
+	url={${5:url}}
+}
+$0
+endsnippet
+
+snippet article "Article reference" b
+@article{${1:name},
+	author={${2:author}},
+	title={${3:title}},
+	journaltitle={${4:journal}},
+	volume={${5:NN}},
+	number={${6:NN}},
+	year={${7:YYYY}},
+	pages={${8:NN}--${9:NN}}
+}
+$0
+endsnippet
+
+snippet book "Book reference" b
+@book{${1:name},
+	author={${2:author}},
+	title={${3:title}},
+	subtitle={${4:subtitle}},
+	year={${5:YYYY}},
+	location={${6:somewhere}},
+	publisher={${7:publisher}},
+	pages={${8:NN}--${9:NN}}
+}
+$0
+endsnippet
+
+snippet inb "In Book reference" b
+@inbook{${1:name},
+	author={${2:author}},
+	title={${3:title}},
+	subtitle={${4:subtitle}},
+	booktitle={${5:book}},
+	editor={${6:editor}},
+	year={${7:YYYY}},
+	location={${8:somewhere}},
+	publisher={${9:publisher}},
+	pages={${10:NN}--${11:NN}}
+}
+$0
+endsnippet

--- a/bundle/ultisnips/UltiSnips/c.snippets
+++ b/bundle/ultisnips/UltiSnips/c.snippets
@@ -1,8 +1,12 @@
-
 ###########################################################################
 #                            TextMate Snippets                            #
 ###########################################################################
-snippet def "#ifndef ... #define ... #endif"
+
+snippet def "#define ..."
+#define ${1}
+endsnippet
+
+snippet ifndef "#ifndef ... #define ... #endif"
 #ifndef ${1/([A-Za-z0-9_]+).*/$1/}
 #define ${1:SYMBOL} ${2:value}
 #endif
@@ -10,7 +14,7 @@ endsnippet
 
 snippet #if "#if #endif" !b
 #if ${1:0}
-${VISUAL:code}$0
+${VISUAL}${0:${VISUAL/(.*)/(?1::code)/}}
 #endif
 endsnippet
 
@@ -32,17 +36,24 @@ $0
 endsnippet
 
 snippet main "main() (main)"
-int main(int argc, char const *argv[])
+int main(int argc, char *argv[])
 {
-	${0:/* code */}
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
 	return 0;
 }
 endsnippet
 
-snippet for "for int loop (fori)"
-for (${4:size_t} ${2:i} = 0; $2 < ${1:count}; ${3:++$2})
+snippet for "for loop (for)"
+for (${2:i} = 0; $2 < ${1:count}; ${3:++$2})
 {
-	${0:/* code */}
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
+}
+endsnippet
+
+snippet fori "for int loop (fori)"
+for (${4:int} ${2:i} = 0; $2 < ${1:count}; ${3:++$2})
+{
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
 }
 endsnippet
 
@@ -71,9 +82,15 @@ snippet td "Typedef"
 typedef ${1:int} ${2:MyCustomType};
 endsnippet
 
+snippet wh "while loop"
+while(${1:/* condition */}) {
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
+}
+endsnippet
+
 snippet do "do...while loop (do)"
 do {
-	${0:/* code */}
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
 } while(${1:/* condition */});
 endsnippet
 
@@ -84,7 +101,24 @@ endsnippet
 snippet if "if .. (if)"
 if (${1:/* condition */})
 {
-	${0:/* code */}
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
+}
+endsnippet
+
+snippet el "else .. (else)"
+else {
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
+}
+endsnippet
+
+snippet ife "if .. else (ife)"
+if (${1:/* condition */})
+{
+	${2:/* code */}
+}
+else
+{
+	${3:/* else */}
 }
 endsnippet
 
@@ -97,6 +131,17 @@ struct ${1:`!p snip.rv = (snip.basename or "name") + "_t"`}
 {
 	${0:/* data */}
 };
+endsnippet
+
+snippet fun "function" b
+${1:void} ${2:function_name}(${3})
+{
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
+}
+endsnippet
+
+snippet fund "function declaration" b
+${1:void} ${2:function_name}(${3});
 endsnippet
 
 # vim:ft=snippets:

--- a/bundle/ultisnips/UltiSnips/cpp.snippets
+++ b/bundle/ultisnips/UltiSnips/cpp.snippets
@@ -22,7 +22,7 @@ endsnippet
 snippet ns "namespace .. (namespace)"
 namespace${1/.+/ /m}${1:`!p snip.rv = snip.basename or "name"`}
 {
-	$0
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
 }${1/.+/ \/* /m}$1${1/.+/ *\/ /m}
 endsnippet
 

--- a/bundle/ultisnips/UltiSnips/cs.snippets
+++ b/bundle/ultisnips/UltiSnips/cs.snippets
@@ -1,0 +1,328 @@
+#######################################################################
+#                      C# Snippets for UltiSnips                      #
+#######################################################################
+
+
+#########################
+#  classes and structs  #
+#########################
+
+snippet namespace "namespace" b
+namespace ${1:MyNamespace}
+{
+	${VISUAL}$0
+}
+endsnippet
+
+snippet class "class" w
+class ${1:MyClass}
+{
+	$0
+}
+endsnippet
+
+snippet struct "struct" w
+struct ${1:MyStruct}
+{
+	$0
+}
+endsnippet
+
+snippet interface "interface" w
+interface I${1:Interface}
+{
+	$0
+}
+endsnippet
+
+snippet enum "enumeration" b
+enum ${1:MyEnum} { ${2:Item} };
+endsnippet
+
+
+############
+#  Main()  #
+############
+
+snippet sim "static int main" b
+static int Main(string[] args)
+{
+	$0
+}
+endsnippet
+
+snippet svm "static void main" b
+static void Main(string[] args)
+{
+	$0
+}
+endsnippet
+
+
+################
+#  properties  #
+################
+
+snippet prop "Simple property declaration" b
+public ${1:int} ${2:MyProperty} { get; set; }
+endsnippet
+
+snippet propfull "Full property declaration" b
+private ${1:int} ${2:_myProperty};
+
+public $1 ${3:MyProperty}
+{
+	get { return $2; }
+	set { $2 = value; }
+}
+endsnippet
+
+snippet propg "Property with a private setter" b
+public ${1:int} ${2:MyProperty} { get; private set; }
+endsnippet
+
+
+############
+#  blocks  #
+############
+
+snippet #if "#if #endif" b
+#if ${1:DEBUG}
+${VISUAL}$0
+#endif
+endsnippet
+
+snippet #region "#region #endregion" b
+#region ${1:Region}
+${VISUAL}$0
+#endregion
+endsnippet
+
+
+###########
+#  loops  #
+###########
+
+snippet for "for loop" b
+for (int ${1:i} = 0; $1 < ${2:10}; $1++)
+{
+	${VISUAL}$0
+}
+endsnippet
+
+snippet forr "for loop (reverse)" b
+for (int ${1:i} = ${2:10}; $1 >= 0; $1--)
+{
+	${VISUAL}$0
+}
+endsnippet
+
+snippet foreach "foreach loop" b
+foreach (${3:var} ${2:item} in ${1:items})
+{
+	${VISUAL}$0
+}
+endsnippet
+
+snippet while "while loop" b
+while (${1:true})
+{
+	${VISUAL}$0
+}
+endsnippet
+
+snippet do "do loop" b
+do
+{
+	${VISUAL}$0
+} while (${1:true});
+endsnippet
+
+
+###############
+#  branching  #
+###############
+
+snippet if "if statement" b
+if ($1)
+{
+	${VISUAL}$0
+}
+endsnippet
+
+snippet ife "if else statement" b
+if ($1)
+{
+	${VISUAL}$0
+}
+else
+{
+}
+endsnippet
+
+snippet elif "else if" b
+else if ($1)
+{
+	$0
+}
+endsnippet
+
+snippet elseif "else if" b
+else if ($1)
+{
+	$0
+}
+endsnippet
+
+snippet ifnn "if not null" b
+if ($1 != null)
+{
+	${VISUAL}$0
+}
+endsnippet
+
+snippet switch "switch statement" b
+switch (${1:statement})
+{
+	case ${2:value}:
+		break;
+
+	default:
+		$0break;
+}
+endsnippet
+
+snippet case "case" b
+case ${1:value}:
+	$2
+	break;
+endsnippet
+
+
+##############
+#  wrappers  #
+##############
+
+snippet using "using statement" b
+using (${1:resource})
+{
+	${VISUAL}$0
+}
+endsnippet
+
+snippet unchecked "unchecked block" b
+unchecked
+{
+	${VISUAL}$0
+}
+endsnippet
+
+snippet checked "checked block" b
+checked
+{
+	${VISUAL}$0
+}
+endsnippet
+
+snippet unsafe "unsafe" b
+unsafe
+{
+	${VISUAL}$0
+}
+endsnippet
+
+
+########################
+#  exception handling  #
+########################
+
+snippet try "try catch block" b
+try
+{
+	${VISUAL}$0
+}
+catch (${1:Exception} ${2:e})
+{
+	throw;
+}
+endsnippet
+
+snippet tryf "try finally block" b
+try
+{
+	${VISUAL}$0
+}
+finally
+{
+}
+endsnippet
+
+snippet throw "throw"
+throw new ${1}Exception("${2}");
+endsnippet
+
+
+##########
+#  LINQ  #
+##########
+
+snippet from "LINQ syntax" b
+var ${1:seq} =
+	from ${2:item1} in ${3:items1}
+	join ${4:item2} in ${5:items2} on $2.${6:prop1} equals $4.${7:prop2}
+	select ${8:$2.prop3}
+	where ${9:clause}
+endsnippet
+
+
+############################
+#  feedback and debugging  #
+############################
+
+snippet da "Debug.Assert" b
+Debug.Assert(${1:true});
+endsnippet
+
+snippet cw "Console.WriteLine" b
+Console.WriteLine("$1");
+endsnippet
+
+# as you first type comma-separated parameters on the right, {n} values appear in the format string
+snippet cwp "Console.WriteLine with parameters" b
+Console.WriteLine("${2:`!p
+snip.rv = ' '.join(['{' + str(i) + '}' for i in range(t[1].count(','))])
+`}"${1:, something});
+endsnippet
+
+snippet mbox "Message box" b
+MessageBox.Show("${1:message}");
+endsnippet
+
+
+##################
+#  full methods  #
+##################
+
+snippet equals "Equals method" b
+public override bool Equals(object obj)
+{
+	if (obj == null || GetType() != obj.GetType())
+	{
+		return false;
+	}
+	$0
+	return base.Equals(obj);
+}
+endsnippet
+
+
+##############
+#  comments  #
+##############
+
+snippet /// "XML comment" b
+/// <summary>
+/// $1
+/// </summary>
+endsnippet
+

--- a/bundle/ultisnips/UltiSnips/d.snippets
+++ b/bundle/ultisnips/UltiSnips/d.snippets
@@ -1,0 +1,583 @@
+# Simple shortcuts
+
+snippet imp "import (imp)" b
+import ${1:std.stdio};
+endsnippet
+
+snippet pimp "public import (pimp)" b
+public import ${1:/*module*/};
+endsnippet
+
+snippet over "override (over)" b
+override ${1:/*function*/}
+endsnippet
+
+snippet al "alias (al)"
+alias ${1:/*orig*/} ${2:/*alias*/};
+endsnippet
+
+snippet mixin "mixin (mixin)" b
+mixin ${1:/*mixed_in*/} ${2:/*name*/};
+endsnippet
+
+snippet new "new (new)"
+new ${1}(${2});
+endsnippet
+
+snippet scpn "@safe const pure nothrow (scpn)"
+@safe const pure nothrow
+endsnippet
+
+snippet spn "@safe pure nothrow (spn)"
+@safe pure nothrow
+endsnippet
+
+snippet cont "continue (cont)"
+continue;
+endsnippet
+
+snippet dis "@disable (dis)" b
+@disable ${1:/*method*/};
+endsnippet
+
+snippet pub "public (pub)" b
+public:
+    ${1:/*members*/}
+endsnippet
+
+snippet priv "private (priv)" b
+private:
+    ${1:/*members*/}
+endsnippet
+
+snippet prot "protected (prot)" b
+protected:
+    ${1:/*members*/}
+endsnippet
+
+snippet pack "package (pack)" b
+package:
+    ${1:/*members*/}
+endsnippet
+
+snippet ret "return (ret)"
+return ${1:/*value to return*/};
+endsnippet
+
+snippet auto "auto (auto)" b
+auto ${1:/*variable*/} = ${2:/*value*/};
+endsnippet
+
+snippet con "const (con)" b
+const ${1:/*variable*/} = ${2:/*value*/};
+endsnippet
+
+snippet siz "size_t (siz)" b
+size_t ${1:/*variable*/} = ${2:/*value*/};
+endsnippet
+
+snippet sup "super (sup)" b
+super(${1:/*args*/});
+endsnippet
+
+# Phobos
+
+snippet tup "tuple (tup)"
+tuple(${1:/*args*/})
+endsnippet
+
+snippet wr "writeln (wr)"
+writeln(${1:/*args*/});
+endsnippet
+
+snippet to "to (to)"
+to!(${1:/*type*/})(${2:/*arg*/})
+endsnippet
+
+snippet enf "enforce (enf)" b
+enforce(${1:/*condition*/},
+        new ${2}Exception(${3:/*args*/}));
+endsnippet
+
+# Branches
+
+snippet if "if .. (if)"
+if(${1:/*condition*/})
+{
+    ${VISUAL}${0:/*code*/}
+}
+endsnippet
+
+snippet ife "if .. else (ife)" b
+if(${1:/*condition*/})
+{
+    ${2:/*code*/}
+}
+else
+{
+    ${3:/*else*/}
+}
+endsnippet
+
+snippet el "else (el)" b
+else
+{
+    ${VISUAL}${1:/*code*/}
+}
+endsnippet
+
+snippet elif "else if (elif)" b
+else if(${1:/*condition*/})
+{
+    ${VISUAL}${0:/*code*/}
+}
+endsnippet
+
+snippet sw "switch (sw)"
+switch(${1:/*var*/})
+{
+    case ${2:/*value*/}:
+        ${3:/*code*/}
+        break;
+    case ${4:/*value*/}:
+        ${5:/*code*/}
+        break;
+    ${7:/*more cases*/}
+    default:
+        ${6:assert(false);}
+}
+endsnippet
+
+snippet fsw "final switch (fsw)"
+switch(${1:/*var*/})
+{
+    case ${2:/*value*/}:
+        ${3:/*code*/}
+        break;
+    case ${4:/*value*/}:
+        ${5:/*code*/}
+        break;
+    ${7:/*more cases*/}
+}
+endsnippet
+
+snippet case "case (case)" b
+case ${1:/*value*/}:
+    ${2:/*code*/}
+    break;
+endsnippet
+
+snippet ?: "ternary operator (?:)"
+${1:/*condition*/} ? ${2:/*then*/} : ${3:/*else*/}$4
+endsnippet
+
+# Loops
+
+snippet do "do while (do)" b
+do
+{
+    ${VISUAL}${2:/*code*/}
+} while(${1:/*condition*/});
+endsnippet
+
+snippet wh "while (wh)" b
+while(${1:/*condition*/})
+{
+    ${VISUAL}${2:/*code*/}
+}
+endsnippet
+
+snippet for "for (for)" b
+for (${4:size_t} ${2:i} = 0; $2 < ${1:count}; ${3:++$2})
+{
+    ${VISUAL}${0:/*code*/}
+}
+endsnippet
+
+snippet forever "forever (forever)" b
+for(;;)
+{
+    ${VISUAL}${0:/*code*/}
+}
+endsnippet
+
+snippet fore "foreach (fore)"
+foreach(${1:/*elem*/}; ${2:/*range*/})
+{
+    ${VISUAL}${3:/*code*/}
+}
+endsnippet
+
+snippet forif "foreach if (forif)" b
+foreach(${1:/*elem*/}; ${2:/*range*/}) if(${3:/*condition*/})
+{
+    ${VISUAL}${4:/*code*/}
+}
+endsnippet
+
+# Contracts
+snippet in "in contract (in)" b
+in
+{
+    assert(${1:/*condition*/}, "${2:error message}");
+    ${3}
+}
+body
+endsnippet
+
+snippet out "out contract (out)" b
+out${1:(result)}
+{
+    assert(${2:/*condition*/}, "${3:error message}");
+    ${4}
+}
+body
+endsnippet
+
+snippet inv "invariant (inv)" b
+invariant()
+{
+    assert(${1:/*condition*/}, "${2:error message}");
+    ${3}
+}
+endsnippet
+
+# Functions (generic)
+
+snippet fun "function definition (fun)"
+${1:void} ${2:/*function name*/}(${3:/*args*/}) ${4:@safe pure nothrow}
+{
+    ${VISUAL}${5:/*code*/}
+}
+endsnippet
+
+snippet void "void function definition (void)"
+void ${1:/*function name*/}(${2:/*args*/}) ${3:@safe pure nothrow}
+{
+    ${VISUAL}${4:/*code*/}
+}
+endsnippet
+
+snippet this "ctor (this)" w
+this(${1:/*args*/})
+{
+    ${VISUAL}${2:/*code*/}
+}
+endsnippet
+
+snippet get "getter property (get)" !
+@property ${1:/*type*/} ${2:/*member_name*/}() const pure nothrow {return ${3:$2_};}
+endsnippet
+
+snippet set "setter property (set)" !
+@property void ${1:/*member_name*/}(${2:/*type*/} rhs) pure nothrow {${3:$1_} = rhs;}
+endsnippet
+
+# Functions (concrete)
+
+snippet main "Main" b
+void main(string[] args)
+{
+    ${VISUAL}${0: /*code*/}
+}
+endsnippet
+
+# Mixins
+
+snippet signal "signal (signal)" b
+mixin Signal!(${1:/*args*/}) ${2:/*name*/};
+endsnippet
+
+# Scope
+
+snippet scope "scope (scope)" b
+scope(${1:exit})
+{
+    ${VISUAL}${2:/*code*/}
+}
+endsnippet
+
+# With
+
+snippet with "with (with)"
+with(${1})
+{
+    ${VISUAL}${2:/*code*/}
+}
+endsnippet
+
+# Exception handling
+
+snippet try "try/catch (try)" b
+try
+{
+    ${VISUAL}${1:/*code to try*/}
+}
+catch(${2}Exception e)
+{
+    ${3:/*handle exception*/}
+}
+endsnippet
+
+snippet tryf "try/catch/finally (tryf)" b
+try
+{
+    ${VISUAL}${1:/*code to try*/}
+}
+catch(${2}Exception e)
+{
+    ${3:/*handle exception*/}
+}
+finally
+{
+    ${4:/*cleanup*/}
+}
+endsnippet
+
+snippet catch "catch (catch)" b
+catch(${1}Exception e)
+{
+    ${2:/*handle exception*/}
+}
+endsnippet
+
+snippet thr "throw (thr)"
+throw new ${1}Exception("${2}");
+endsnippet
+
+
+# Type declarations
+
+snippet struct "struct (struct)"
+struct ${1:`!p snip.rv = (snip.basename or "name")`}
+{
+    ${2}
+}
+endsnippet
+
+snippet union "union (union)"
+union ${1:`!p snip.rv = (snip.basename or "name")`}
+{
+    ${2}
+}
+endsnippet
+
+snippet class "class (class)"
+class ${1:`!p snip.rv = (snip.basename or "name")`}
+{
+    ${2}
+}
+endsnippet
+
+snippet inter "interface (inter)"
+interface ${1:`!p snip.rv = (snip.basename or "name")`}
+{
+    ${2}
+}
+endsnippet
+
+snippet enum "enum (enum)"
+enum ${1:`!p snip.rv = (snip.basename or "name")`}
+{
+    ${2}
+}
+endsnippet
+
+
+# Exception declarations
+
+snippet exc "exception declaration (exc)" b
+/// ${3:/*documentation*/}
+class ${1}Exception : ${2}Exception 
+{
+    public this(string msg, string file = __FILE__, int line = __LINE__)
+    {
+        super(msg, file, line);
+    }
+}
+endsnippet
+
+
+# Conditional compilation
+
+snippet version "version (version)" b
+version(${1:/*version name*/})
+{
+    ${VISUAL}${2:/*code*/}
+}
+endsnippet
+
+snippet debug "debug" b
+debug
+{
+    ${VISUAL}${1:/*code*/}
+}
+endsnippet
+
+
+# Templates
+
+snippet temp "template (temp)" b
+template ${2:/*name*/}(${1:/*args*/})
+{
+    ${3:/*code*/}
+}
+endsnippet
+
+
+# Asserts
+
+snippet ass "assert (ass)" b
+assert(${1:false}, "${2:TODO}");
+
+endsnippet
+
+
+# Unittests
+
+snippet unittest "unittest (unittest)" b
+unittest
+{
+    ${1:/*code*/}
+}
+endsnippet
+
+
+# Common member functions
+
+snippet opDis "opDispatch (opDis)" b
+${1:/*return type*/} opDispatch(string s)()
+{
+    ${2:/*code*/};
+}
+endsnippet
+
+snippet op= "opAssign (op=)" b
+void opAssign(${1} rhs) ${2:@safe pure nothrow}
+{
+    ${2:/*code*/}
+}
+endsnippet
+
+snippet opCmp "opCmp (opCmp)" b
+int opCmp(${1} rhs) @safe const pure nothrow
+{
+    ${2:/*code*/}
+}
+endsnippet
+
+snippet opApply "opApply (opApply)" b
+int opApply(int delegate(ref ${1:/*iterated type/s*/}) dg)
+{
+    int result = 0;
+    ${2:/*loop*/}
+    {
+        result = dg(${3:/*arg/s*/});
+        if(result){break;}
+    }
+    return result;
+}
+endsnippet
+
+snippet toString "toString (toString)" b
+string toString() @safe const pure nothrow
+{
+    ${1:/*code*/}
+}
+endsnippet
+
+
+# Comments
+
+
+snippet todo "TODO (todo)" !
+// TODO: ${1}
+endsnippet
+
+
+
+# DDoc
+
+snippet doc "generic ddoc block (doc)" b
+/// ${1:description}
+///
+/// ${2:details}
+endsnippet
+
+snippet fdoc "function ddoc block (fdoc)" b
+/// ${1:description}
+///
+/// ${2:Params:  ${3:param} = ${4:param description}
+///          ${5}}
+///
+/// ${6:Returns: ${7:return value}}
+///
+/// ${8:Throws:  ${9}Exception ${10}}
+endsnippet
+
+snippet Par "Params (Par)"
+Params:  ${1:param} = ${2:param description}
+///         ${3}
+endsnippet
+
+snippet Ret "Returns (Ret)"
+Returns:  ${1:return value/s}
+endsnippet
+
+snippet Thr "Throws (Thr)"
+Throws:  ${1}Exception ${2}
+endsnippet
+
+snippet Example "Examples (Example)"
+Examples:
+/// --------------------
+/// ${1:example code}
+/// --------------------
+endsnippet
+
+
+# License blocks
+
+snippet gpl "GPL (gpl)" b
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// 
+// Copyright (C) ${1:Author}, `!v strftime("%Y")`
+
+${2}
+endsnippet
+
+snippet boost "Boost (boost)" b
+//          Copyright ${1:Author} `!v strftime("%Y")`.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+${2}
+endsnippet
+
+
+# New module
+
+snippet module "New module (module)" b
+//          Copyright ${1:Author} `!v strftime("%Y")`.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+module ${2}.`!v Filename('$1', 'name')`;
+
+
+${3}
+endsnippet

--- a/bundle/ultisnips/UltiSnips/eruby.snippets
+++ b/bundle/ultisnips/UltiSnips/eruby.snippets
@@ -14,9 +14,9 @@ def textmate_var(var, snip):
     lookup = dict(
        TM_RAILS_TEMPLATE_START_RUBY_EXPR = snip.opt('g:tm_rails_template_start_ruby_expr', '<%= '),
        TM_RAILS_TEMPLATE_END_RUBY_EXPR = snip.opt('g:tm_rails_template_end_ruby_expr', ' %>'),
-       TM_RAILS_TEMPLATE_START_RUBY_INLINE = snip.opt('g:tm_rails_template_start_ruby_inline', ' %>'),
+       TM_RAILS_TEMPLATE_START_RUBY_INLINE = snip.opt('g:tm_rails_template_start_ruby_inline', '<% '),
        TM_RAILS_TEMPLATE_END_RUBY_INLINE = snip.opt('g:tm_rails_template_end_ruby_inline', ' %>'),
-       TM_RAILS_TEMPLATE_END_RUBY_BLOCK = 'end'
+       TM_RAILS_TEMPLATE_END_RUBY_BLOCK = '<% end %>'
     )
 
     snip.rv = lookup[var]
@@ -66,7 +66,7 @@ snippet ffhf "form_for hidden_field 2"
 endsnippet
 
 snippet ffl "form_for label 2"
-`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR}f.label :${1:attribute', snip)`${2:, "${3:${1/[[:alpha:]]+|(_)/(?1: :\u$0)/g}}"}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
+`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR', snip)`f.label :${1:attribute}${2:, "${3:${1/[[:alpha:]]+|(_)/(?1: :\u$0)/g}}"}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
 endsnippet
 
 snippet ffpf "form_for password_field 2"
@@ -114,7 +114,7 @@ snippet f. "f.hidden_field"
 endsnippet
 
 snippet f. "f.label"
-`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR}f.label :${1:attribute', snip)`${2:, "${3:${1/[[:alpha:]]+|(_)/(?1: :\u$0)/g}}"}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
+`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR', snip)`f.label :${1:attribute}${2:, "${3:${1/[[:alpha:]]+|(_)/(?1: :\u$0)/g}}"}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
 endsnippet
 
 snippet f. "f.password_field"

--- a/bundle/ultisnips/UltiSnips/html.snippets
+++ b/bundle/ultisnips/UltiSnips/html.snippets
@@ -167,8 +167,8 @@ snip.rv = snip.fn and 'Hallo' or 'Nothin'
 endsnippet
 
 snippet div "XHTML <div>"
-<div${1: id="${2:name}"}>
-	$0
+<div`!p snip.rv=' id="' if t[1] else ""`${1:name}`!p snip.rv = '"' if t[1] else ""``!p snip.rv=' class="' if t[2] else ""`${2:name}`!p snip.rv = '"' if t[2] else ""`>
+   $0
 </div>
 endsnippet
 
@@ -234,7 +234,7 @@ snippet p "paragraph"
 endsnippet
 
 snippet li "list item"
-<li></li>
+<li>$0</li>
 endsnippet
 
 snippet ul "unordered list"
@@ -288,9 +288,6 @@ snippet html5 "HTML5 Template"
     <header>
         ${2}
     </header>
-    <content>
-        ${3}
-    </content>
     <footer>
         ${4}
     </footer>

--- a/bundle/ultisnips/UltiSnips/java.snippets
+++ b/bundle/ultisnips/UltiSnips/java.snippets
@@ -5,14 +5,52 @@
 # Many of the snippets here use a global option called
 # "g:ultisnips_java_brace_style" which, if set to "nl" will put a newline
 # before '{' braces.
+# Setting "g:ultisnips_java_junit" will change how the test method snippet
+# looks, it is defaulted to junit4, setting this option to 3 will remove the
+# @Test annotation from the method
 
 global !p
+def junit(snip):
+    if snip.opt("g:ultisnips_java_junit", "") == "3":
+        snip += ""
+    else:
+        snip.rv += "@Test\n\t"
+
 def nl(snip):
     if snip.opt("g:ultisnips_java_brace_style", "") == "nl":
         snip += ""
     else:
         snip.rv += " "
+def getArgs(group):
+	import re
+	word = re.compile('[a-zA-Z><.]+ \w+')
+	return [i.split(" ") for i in word.findall(group) ]
+
+def camel(word):
+	return word[0].upper() + word[1:]
+
 endglobal
+
+snippet sleep "try sleep catch" !b
+try {
+	Thread.sleep(${1:1000});
+} catch (InterruptedException e){
+	e.printStackTrace();
+}
+endsnippet
+
+snippet /i|n/ "new primitive or int" !br
+${1:int} ${2:i} = ${3:1};
+$0
+endsnippet
+
+snippet /o|v/ "new Object or variable" !br
+${1:Object} ${2:var} = new $1(${3});
+endsnippet
+
+snippet f "field" !b
+${1:private} ${2:String} ${3:`!p snip.rv = t[2].lower()`};
+endsnippet
 
 snippet ab "abstract" b
 abstract 
@@ -20,6 +58,18 @@ endsnippet
 
 snippet as "assert" b
 assert ${1:test}${2/(.+)/(?1: \: ")/}${2:Failure message}${2/(.+)/(?1:")/};$0
+endsnippet
+
+snippet at "assert true" !b
+assertTrue(${1:actual});
+endsnippet
+
+snippet af "assert false" !b
+assertFalse(${1:actual});$0
+endsnippet
+
+snippet ae "assert equals" !b
+assertEquals(${1:expected}, ${2:actual});
 endsnippet
 
 snippet br "break"
@@ -39,19 +89,85 @@ catch (${1:Exception} ${2:e})`!p nl(snip)`{
 }
 endsnippet
 
-snippet cl "class" b
-class ${1:`!p
+snippet cle "class extends" b
+public class ${1:`!p
 snip.rv = snip.basename or "untitled"`} ${2:extends ${3:Parent} }${4:implements ${5:Interface} }{
 	$0
 }
 endsnippet
 
+snippet clc "class with constructor, fields, setter and getters" !b
+public class `!p
+snip.rv = snip.basename or "untitled"` {
+`!p
+args = getArgs(t[1])
+if len(args) == 0: snip.rv = ""
+for i in args:
+	snip.rv += "\n\tprivate " + i[0] + " " + i[1]+ ";"
+if len(args) > 0:
+	snip.rv += "\n"`
+	public `!p snip.rv = snip.basename or "unknown"`($1) { `!p
+args = getArgs(t[1])
+for i in args:
+	snip.rv += "\n\t\tthis." + i[1] + " = " + i[1] + ";"
+if len(args) == 0:
+	snip.rv += "\n"`
+	}$0
+`!p
+args = getArgs(t[1])
+if len(args) == 0: snip.rv = ""
+for i in args:
+	snip.rv += "\n\tpublic void set" + camel(i[1]) + "(" + i[0] + " " + i[1] + ") {\n" + "\
+	\tthis." + i[1] + " = " + i[1] + ";\n\t}\n"
+
+	snip.rv += "\n\tpublic " + i[0] + " get" + camel(i[1]) + "() {\
+	\n\t\treturn " + i[1] + ";\n\t}\n"
+`
+}
+endsnippet
+
+snippet clc "class with constructor, with field names" b
+public class `!p
+snip.rv = snip.basename or "untitled"` {
+`!p
+args = getArgs(t[1])
+for i in args:
+	snip.rv += "\n\tprivate " + i[0] + " " + i[1]+ ";"
+if len(args) > 0:
+	snip.rv += "\n"`
+	public `!p snip.rv = snip.basename or "unknown"`($1) { `!p
+args = getArgs(t[1])
+for i in args:
+	snip.rv += "\n\t\tthis." + i[1] + " = " + i[1]
+if len(args) == 0:
+	snip.rv += "\n"`
+	}
+}
+endsnippet
+
+snippet clc "class and constructor" b
+public class `!p
+snip.rv = snip.basename or "untitled"` {
+
+	public `!p snip.rv = snip.basename or "untitled"`($2) {
+		$0
+	}
+}
+endsnippet
+
+snippet cl "class" b
+public class ${1:`!p
+snip.rv = snip.basename or "untitled"`} {
+	$0
+}
+endsnippet
+
 snippet cos "constant string" b
-static public final String ${1:var} = "$2";$0
+public static final String ${1:var} = "$2";$0
 endsnippet
 
 snippet co "constant" b
-static public final ${1:String} ${2:var} = $3;$0
+public static final ${1:String} ${2:var} = $3;$0
 endsnippet
 
 snippet de "default" b
@@ -81,6 +197,12 @@ for ($1 : $2)`!p nl(snip)`{
 }
 endsnippet
 
+snippet fori "for" b
+for (int ${1:i} = 0; $1 < ${2:10}; $1++)`!p nl(snip)`{
+	$0
+}
+endsnippet
+
 snippet for "for" b
 for ($1; $2; $3)`!p nl(snip)`{
 	$0
@@ -99,12 +221,54 @@ $0
 endsnippet
 
 snippet im "import"  b
-import 
+import ${1:java}.${2:util}.$0
 endsnippet
 
 snippet in "interface" b
 interface ${1:`!p snip.rv = snip.basename or "untitled"`} ${2:extends ${3:Parent} }{
 	$0
+}
+endsnippet
+
+snippet cc "constructor call or setter body"
+this.${1:var} = $1;
+endsnippet
+
+snippet list "Collections List" b
+List<${1:String}> ${2:list} = new ${3:Array}List<$1>();
+endsnippet
+
+snippet map "Collections Map" b
+Map<${1:String}, ${2:String}> ${3:map} = new ${4:Hash}Map<$1, $2>();
+endsnippet
+
+snippet set "Collections Set" !b
+Set<${1:String}> ${2:set} = new ${3:Hash}Set<$1>();
+endsnippet
+
+snippet /Str?|str/ "String" !br
+String 
+endsnippet
+
+snippet cn "Constructor" b
+public `!p snip.rv = snip.basename or "untitled"`(${1:}) {
+	$0
+}
+endsnippet
+
+snippet cn "constructor, \w fields + assigments" b
+ `!p
+args = getArgs(t[1])
+for i in args:
+	snip.rv += "\n\tprivate " + i[0] + " " + i[1]+ ";"
+if len(args) > 0:
+	snip.rv += "\n"`
+public `!p snip.rv = snip.basename or "unknown"`($1) { `!p
+args = getArgs(t[1])
+for i in args:
+	snip.rv += "\n\t\tthis." + i[1] + " = " + i[1]
+if len(args) == 0:
+	snip.rv += "\n"`
 }
 endsnippet
 
@@ -134,11 +298,66 @@ public static void main(String[] args)`!p nl(snip)`{
 }
 endsnippet
 
-snippet m "method" b
-${1:void} ${2:method}($3) ${4:throws $5 }{
+snippet try "try/catch" !b
+try {
+	$1
+} catch(${2:Exception} ${3:e}){
+	${4:e.printStackTrace();}
+}
+endsnippet
+
+snippet mt "method throws" b!
+${1:private} ${2:void} ${3:method}(${4}) ${5:throws $6 }{
 	$0
 }
+endsnippet
 
+snippet m  "method" b
+${1:private} ${2:void} ${3:method}(${4}) {
+	$0
+}
+endsnippet
+
+snippet md "Method With javadoc" !b
+/**
+ * ${7:Short Description}`!p
+for i in getArgs(t[4]):
+	snip.rv += "\n\t * @param " + i[1] + " usage..."`
+ * `!p
+if "throws" in t[5]:
+	snip.rv = "\n\t * @throws " + t[6]
+else:
+	snip.rv = ""` `!p
+if not "void" in t[2]:
+	snip.rv = "\n\t * @return object"
+else:
+	snip.rv = ""`
+ **/
+${1:public} ${2:void} ${3:method}($4) ${5:throws $6 }{
+	$0
+}
+endsnippet
+
+snippet /get(ter)?/ "getter" !br
+public ${1:String} get${2:Name}() {
+	return `!p snip.rv = t[2].lower()`;
+}
+endsnippet
+
+snippet /set(ter)?/ "setter" !br
+public void set${1:Name}(${2:String} $1) {
+	return this.`!p snip.rv = t[1].lower()` = `!p snip.rv = t[1].lower()`;
+}
+endsnippet
+
+snippet /se?tge?t|ge?tse?t|gs/ "setter and getter" !br
+public void set${1:Name}(${2:String} `!p snip.rv = t[1].lower()`) {
+	this.`!p snip.rv = t[1].lower()` = `!p snip.rv = t[1].lower()`;
+}
+
+public $2 get$1() {
+	return `!p snip.rv = t[1].lower()`;
+}
 endsnippet
 
 snippet pa "package" b
@@ -175,7 +394,7 @@ endsnippet
 
 snippet sw "switch" b
 switch ($1)`!p nl(snip)`{
-	$0
+	case $2: $0
 }
 endsnippet
 
@@ -190,17 +409,19 @@ public class ${1:`!p snip.rv = snip.basename or "untitled"`} extends ${2:TestCas
 endsnippet
 
 snippet t "test" b
-public void test${1:Name}() throws Exception`!p nl(snip)`{
+`!p junit(snip)`public void test${1:Name}() {
+	$0
+}
+endsnippet
+
+snippet tt "test throws" b
+`!p junit(snip)`public void test${1:Name}() ${2:throws Exception }{
 	$0
 }
 endsnippet
 
 snippet th "throw" b
-throw $0
-endsnippet
-
-snippet v "variable" b
-${1:String} ${2:var}${3: = ${0:null}};
+throw new $0
 endsnippet
 
 snippet wh "while" b

--- a/bundle/ultisnips/UltiSnips/javascript.snippets
+++ b/bundle/ultisnips/UltiSnips/javascript.snippets
@@ -6,19 +6,19 @@ getElement${1/(T)|.*/(?1:s)/}By${1:T}${1/(T)|(I)|.*/(?1:agName)(?2:d)/}('$2')
 endsnippet
 
 snippet '':f "object method string"
-'${1:${2:#thing}:${3:click}}': function(element){
-	$0
+'${1:${2:#thing}:${3:click}}': function(element) {
+	${VISUAL}$0
 }${10:,}
 endsnippet
 
 snippet :f "Object Method"
-${1:method_name}: function(${3:attribute}){
-	$0
+${1:method_name}: function(${3:attribute}) {
+	${VISUAL}$0
 }${10:,}
 endsnippet
 
 snippet :, "Object Value JS"
-${1:value_name}:${0:value},
+${1:value_name}: ${0:value},
 endsnippet
 
 snippet : "Object key key: 'value'"
@@ -26,40 +26,93 @@ ${1:key}: ${2:"${3:value}"}${4:, }
 endsnippet
 
 snippet proto "Prototype (proto)"
-${1:class_name}.prototype.${2:method_name} = function(${3:first_argument}) ,,{
-	${0:// body...}
+${1:class_name}.prototype.${2:method_name} = function(${3:first_argument}) {
+	${VISUAL}$0
 };
- 
+
 endsnippet
 
 snippet for "for (...) {...} (faster)"
-for (var ${2:i} = ${1:Things}.length - 1; $2 >= 0; $2--){
-	${3:$1[$2]}$0
+for (var ${2:i} = ${1:Things}.length - 1; $2 >= 0; $2--) {
+	${3:$1[$2]}${VISUAL}$0
 };
 endsnippet
 
 snippet for "for (...) {...}"
 for (var ${2:i}=0; $2 < ${1:Things}.length; $2++) {
-	${3:$1[$2]}$0
+	${3:$1[$2]}${VISUAL}$0
 };
 endsnippet
 
 snippet fun "function (fun)"
 function ${1:function_name} (${2:argument}) {
-	${0:// body...}
+	${VISUAL}$0
 }
 endsnippet
 
+snippet iife "Immediately-Invoked Function Expression (iife)"
+(function (${1:argument}) {
+	${VISUAL}$0
+}(${2:$1}));
+endsnippet
+
 snippet ife "if ___ else"
-if (${1:true}) {$0} else{};
+if (${1:condition}) {
+  ${2://code}
+}
+else {
+  ${3://code}
+}
 endsnippet
 
 snippet if "if"
-if (${1:true}) {$0};
+if (${1:condition}) {
+  ${VISUAL}$0
+}
 endsnippet
 
 snippet timeout "setTimeout function"
-setTimeout(function() {$0}${2:}, ${1:10});
+setTimeout(function() {
+  ${VISUAL}$0
+}${2:.bind(${3:this})}, ${1:10});
+endsnippet
+
+# Snippets for Console Debug Output
+
+snippet cl "console.log"
+console.log(${1:"${2:value}"});
+endsnippet
+
+snippet cw "console.warn"
+console.warn(${1:"${2:value}"});
+endsnippet
+
+snippet ce "console.error"
+console.error(${1:"${2:value}"});
+endsnippet
+
+snippet ca "console.assert"
+console.assert(${1:assertion}, ${2:"${3:message}"});
+endsnippet
+
+snippet cgroup "console.group"
+console.group("${1:label}");
+${VISUAL}$0
+console.groupEnd();
+endsnippet
+
+snippet ctime "console.time"
+console.time("${1:label}");
+${VISUAL}$0
+console.timeEnd("$1");
+endsnippet
+
+snippet ctimestamp "console.timestamp"
+console.timeStamp("${1:label}")
+endsnippet
+
+snippet ctrace "console.trace"
+console.trace();
 endsnippet
 
 # vim:ft=snippets:

--- a/bundle/ultisnips/UltiSnips/ledger.snippets
+++ b/bundle/ultisnips/UltiSnips/ledger.snippets
@@ -1,0 +1,6 @@
+snippet t "Transaction" b
+${1:`!v strftime("%Y")`}-${2:`!v strftime("%m")`}-${3:`!v strftime("%d")`} ${4:*} ${5:Payee}
+	${6:Expenses}			\$${7:0.00}
+	${8:Assets:Checking}
+$0
+endsnippet

--- a/bundle/ultisnips/UltiSnips/lhaskell.snippets
+++ b/bundle/ultisnips/UltiSnips/lhaskell.snippets
@@ -1,0 +1,2 @@
+extends haskell
+

--- a/bundle/ultisnips/UltiSnips/ocaml.snippets
+++ b/bundle/ultisnips/UltiSnips/ocaml.snippets
@@ -1,0 +1,172 @@
+snippet rs "raise" b
+raise (${1:Not_found})
+endsnippet
+
+snippet open "open"
+let open ${1:module} in
+${2:e}
+endsnippet
+
+snippet try "try"
+try ${1:e}
+with ${2:Not_found} -> ${3:()}
+endsnippet
+
+snippet ref "ref"
+let ${1:name} = ref ${2:val} in
+${3:e}
+endsnippet
+
+snippet matchl "pattern match on a list"
+match ${1:list} with
+| [] -> ${2:()}
+| x::xs -> ${3:()}
+endsnippet
+
+snippet matcho "pattern match on an option type"
+match ${1:x} with
+| Some(${2:y}) -> ${3:()}
+| None -> ${4:()}
+endsnippet
+
+snippet fun "anonymous function"
+(fun ${1:x} -> ${2:x})
+endsnippet
+
+snippet cc "commment"
+(* ${1:comment} *)
+endsnippet
+
+snippet let "let .. in binding"
+let ${1:x} = ${2:v} in
+${3:e}
+endsnippet
+
+snippet lr "let rec"
+let rec ${1:f} =
+  ${2:expr}
+endsnippet
+
+snippet if "if"
+if ${1:(* condition *)} then
+  ${2:(* A *)}
+else
+  ${3:(* B *)}
+endsnippet
+
+snippet If "If"
+if ${1:(* condition *)} then
+  ${2:(* A *)}
+endsnippet
+
+snippet while "while"
+while ${1:(* condition *)} do
+  ${2:(* A *)}
+done
+endsnippet
+
+snippet for "for"
+for ${1:i} = ${2:1} to ${3:10} do
+  ${4:(* BODY *)}
+done
+endsnippet
+
+snippet match "match"
+match ${1:(* e1 *)} with
+| ${2:p} -> ${3:e2}
+endsnippet
+
+snippet Match "match"
+match ${1:(* e1 *)} with
+| ${2:p} -> ${3:e2}
+endsnippet
+
+snippet class "class"
+class ${1:name} = object
+  ${2:methods}
+end
+endsnippet
+
+snippet obj "obj"
+object
+  ${2:methods}
+end
+endsnippet
+
+snippet Obj "object"
+object (self)
+  ${2:methods}
+end
+endsnippet
+
+snippet {{ "object functional update"
+{< ${1:x} = ${2:y} >}
+endsnippet
+
+snippet beg "beg"
+begin
+  ${1:block}
+end
+endsnippet
+
+snippet ml "module instantiantion with functor"
+module ${1:Mod} = ${2:Functor}(${3:Arg})
+endsnippet
+
+snippet mod "module - no signature"
+module ${1:(* Name *)} = struct
+  ${2:(* BODY *)}
+end
+endsnippet
+
+snippet Mod "module with signature"
+module ${1:(* Name *)} : ${2:(* SIG *)} = struct
+  ${3:(* BODY *)}
+end
+endsnippet
+
+snippet sig "anonymous signature"
+sig
+  ${2:(* BODY *)}
+end
+endsnippet
+
+snippet sigf "functor signature or anonymous functor"
+functor (${1:Arg} : ${2:ARG}) -> ${3:(* BODY *)}
+endsnippet
+
+snippet func "define functor - no signature"
+module ${1:M} (${2:Arg} : ${3:ARG}) = struct
+  ${4:(* BODY *)}
+end
+endsnippet
+
+snippet Func "define functor - with signature"
+module ${1:M} (${2:Arg} : ${3:ARG}) : ${4:SIG} = struct
+  ${5:(* BODY *)}
+end
+endsnippet
+
+snippet mot "Declare module signature"
+module type ${1:(* Name *)} = sig
+  ${2:(* BODY *)}
+end
+endsnippet
+
+snippet module "Module with anonymous signature"
+module ${1:(* Name *)} : sig
+  ${2:(* SIGNATURE *)}
+end = struct
+  ${3:(* BODY *)}
+end
+endsnippet
+
+snippet oo "odoc"
+(** ${1:odoc} *)
+endsnippet
+
+snippet qt "inline qtest"
+(*$T ${1:name}
+   ${2:test}
+*)
+endsnippet

--- a/bundle/ultisnips/UltiSnips/perl.snippets
+++ b/bundle/ultisnips/UltiSnips/perl.snippets
@@ -49,7 +49,7 @@ ${1:expression} while ${2:condition};
 endsnippet
 
 snippet test "Test"
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 use strict;
 use Test::More tests => ${1:1};
@@ -105,8 +105,7 @@ if ($1) {
 endsnippet
 
 snippet slurp "slurp"
-my $${1:var};
-{ local $/ = undef; local *FILE; open FILE, "<${2:file}"; $$1 = <FILE>; close FILE }
+my $${1:var} = do { local $/ = undef; open my $fh, '<', ${2:$file}; <$fh> };
 
 endsnippet
 

--- a/bundle/ultisnips/UltiSnips/php.snippets
+++ b/bundle/ultisnips/UltiSnips/php.snippets
@@ -193,7 +193,6 @@ function ${1:name}(${2:$param})
 }
 $0
 endsnippet
-# :vim:ft=snippets
 
 snippet fore "Foreach loop"
 foreach ($${1:variable} as $${3:value}){
@@ -207,7 +206,6 @@ $$1 = new $1($2);
 $0
 endsnippet
 
-
 snippet ife "if else"
 if (${1:/* condition */}) {
     ${2:// code...}
@@ -216,7 +214,6 @@ if (${1:/* condition */}) {
 }
 $0
 endsnippet
-
 
 snippet class "Class declaration template" !b
 /**

--- a/bundle/ultisnips/UltiSnips/puppet.snippets
+++ b/bundle/ultisnips/UltiSnips/puppet.snippets
@@ -1,78 +1,232 @@
 # Snippets for Puppet
 
-snippet /^class/ "Class declaration" r
-class ${1:name} {
-    ${0:# body}
+#########################################################################
+#  Python helper code                                                   #
+#########################################################################
+
+global !p
+import vim
+import os.path
+def get_module_namespace_and_basename():
+    """This function will try to guess the current class or define name you are
+    trying to create. Note that for this to work you should be using the module
+    structure as per the style guide. Examples inputs and it's output
+    * /home/nikolavp/puppet/modules/collectd/manifests/init.pp -> collectd
+    * /home/nikolavp/puppet/modules/collectd/manfistes/mysql.pp -> collectd::mysql
+    """
+    first_time = True
+    current_file_path_without_ext = vim.eval('expand("%:p:r")') or ""
+    if not current_file_path_without_ext:
+        return "name"
+    parts = os.path.split(current_file_path_without_ext)
+    namespace = ''
+    while parts[0] and parts[0] != '/':
+        if parts[1] == 'init' and first_time and not namespace:
+            first_time = False
+            parts = os.path.split(parts[0])
+            continue
+        if parts[1] == 'manifests':
+            return os.path.split(parts[0])[1] + ('::' + namespace).rstrip(':')
+        else:
+            namespace = parts[1] + '::' + namespace
+        parts = os.path.split(parts[0])
+    # couldn't guess the namespace. The user is editing a raw file in no module like the site.pp file
+    return "name"
+endglobal
+
+###############################################################################
+#  Puppet Language Constructs                                                 #
+#    See http://docs.puppetlabs.com/puppet/latest/reference/lang_summary.html #
+###############################################################################
+
+snippet class "Class declaration" b
+class ${1:`!p snip.rv = get_module_namespace_and_basename()`} {
+  ${0:# body}
 }
 endsnippet
 
-snippet File "Defaults for file" b
-File {
-    owner => ${1:username},
-    group => ${2:groupname},
+snippet define "Definition" b
+define ${1:`!p snip.rv = get_module_namespace_and_basename()`} {
+  ${0:# body}
 }
 endsnippet
 
-# Resource types
-snippet package "Package resource type" b
-package { "${1:name}":
-    ensure => ${2:installed},
+#################################################################
+#  Puppet Types                                                 #
+#    See http://docs.puppetlabs.com/references/latest/type.html #
+#################################################################
+
+snippet cron "Cron resource type" b
+cron { '${1:name}':
+  user    => ${2:user},
+  command => '${3:command}',
+  minute  => ${3:minute},
+  hour    => ${4:hour},
+}
+endsnippet
+
+snippet exec "Exec resource type" b
+exec { '${1:command}':
+  refreshonly => true,
 }
 endsnippet
 
 snippet file "File resource type" b
-file { "${1:name}":
-    source => "puppet://${2:path}",
-    mode   => ${3:mode},
+file { '${1:name}':
+  source => "puppet://${2:path}",
+  mode   => ${3:mode},
+endsnippet
+
+snippet File "Defaults for file" b
+File {
+  owner => ${1:username},
+  group => ${2:groupname},
+}
 endsnippet
 
 snippet group "Group resource type" b
-group { "${1:groupname}":
-    ensure => ${3:present},
-    gid    => ${2:gid},
-endsnippet
-
-snippet user "user resource type" b
-group { "${1:username}":
-    ensure     => ${2:present},
-    uid        => ${3:uid},
-    gid        => ${4:gid},
-    comment    => ${5:gecos},
-    home       => ${6:homedirectory},
-    managehome => false,
-    require    => Group["${7:group"],
-endsnippet
-
-snippet exec "Exec resource type" b
-exec { "${1:command}":
-    refreshonly => true,
-}
-endsnippet
-
-snippet cron "Cron resource type" b
-cron { "${1:name}":
-    user    => ${2:user},
-    command => "${3:command}",
-    minute  => ${3:minute},
-    hour    => ${4:hour},
-}
+group { '${1:groupname}':
+  ensure => ${3:present},
+  gid    => ${2:gid},
 endsnippet
 
 snippet mount "Mount resource type" b
-mount { "${1:path}":
-    device  => "${2:/dev}",
-    fstype  => "${3:filesystem}",
-    ensure  => mounted,
-    options => "rw,errors=remount-ro",
+mount { '${1:path}':
+  device  => '${2:/dev}',
+  fstype  => '${3:filesystem}',
+  ensure  => mounted,
+  options => 'rw,errors=remount-ro',
 }
 endsnippet
 
-snippet service "Service resource type" b
-service { "${1:name}":
-    hasstatus => true,
-    enable    => true,
-    ensure    => running,
+snippet package "Package resource type" b
+package { '${1:name}':
+  ensure => ${2:installed},
 }
+endsnippet
+
+snippet user "user resource type" b
+user { '${1:username}':
+  ensure     => ${2:present},
+  uid        => ${3:uid},
+  gid        => ${4:gid},
+  comment    => ${5:gecos},
+  home       => ${6:homedirectory},
+  managehome => false,
+  require    => Group['${7:group'}],
+endsnippet
+
+snippet service "Service resource type" b
+service { '${1:name}':
+  hasstatus => true,
+  enable    => true,
+  ensure    => running,
+}
+endsnippet
+
+########################################################################
+#  Puppet Functions                                                    #
+#    See http://docs.puppetlabs.com/references/latest/function.html    #
+########################################################################
+
+snippet alert "Alert Function" !b
+alert("${1:message}")${0}
+endsnippet
+
+snippet crit "Crit Function" !b
+crit("${1:message}")${0}
+endsnippet
+
+snippet debug "Debug Function" !b
+debug("${1:message}")${0}
+endsnippet
+
+snippet defined "Defined Function" !b
+defined(${1:Resource}["${2:name}"])${0}
+endsnippet
+
+snippet emerg "Emerg Function" !b
+emerg("${1:message}")${0}
+endsnippet
+
+snippet extlookup "Simple Extlookup" b
+$${1:Variable} = extlookup("${2:Lookup}")${0}
+endsnippet
+
+snippet extlookup "Extlookup with defaults" b
+$${1:Variable} = extlookup("${2:Lookup}", ${3:Default})${0}
+endsnippet
+
+snippet extlookup "Extlookup with defaults and custom data file" b
+$${1:Variable} = extlookup("${2:Lookup}", ${3:Default}, ${4:Data Source})${0}
+endsnippet
+
+snippet fail "Fail Function" !b
+fail("${1:message}")${0}
+endsnippet
+
+snippet hiera "Hiera Function" b
+$${1:Variable} = hiera("${2:Lookup}")${0}
+endsnippet
+
+snippet hiera "Hiera with defaults" b
+$${1:Variable} = hiera("${2:Lookup}", ${3:Default})${0}
+endsnippet
+
+snippet hiera "Hiera with defaults and override" b
+$${1:Variable} = hiera("${2:Lookup}", ${3:Default}, ${4:Override})${0}
+endsnippet
+
+snippet hiera_hash "Hiera Hash Function" b
+$${1:Variable} = hiera_hash("${2:Lookup}")${0}
+endsnippet
+
+snippet hiera_hash "Hiera Hash with defaults" b
+$${1:Variable} = hiera_hash("${2:Lookup}", ${3:Default})${0}
+endsnippet
+
+snippet hiera_hash "Hiera Hash with defaults and override" b
+$${1:Variable} = hiera_hash("${2:Lookup}", ${3:Default}, ${4:Override})${0}
+endsnippet
+
+snippet hiera_include "Hiera Include Function" b
+hiera_include("${1:Lookup}")${0}
+endsnippet
+
+snippet include "Include Function" !b
+include ${1:classname}${0}
+endsnippet
+
+snippet info "Info Function" !b
+info("${1:message}")${0}
+endsnippet
+
+snippet inline_template "Inline Template Function" !b
+inline_template("<%= ${1:template} %>")${0}
+endsnippet
+
+snippet notice "Notice Function" !b
+notice("${1:message}")${0}
+endsnippet
+
+snippet realize "Realize Function" !b
+realize(${1:Resource}["${2:name}"])${0}
+endsnippet
+
+snippet regsubst "Regsubst Function" !b
+regsubst($${1:Target}, '${2:regexp}', '${3:replacement}')${0}
+endsnippet
+
+snippet split "Split Function" !b
+$${1:Variable} = split($${1:Target}, '${2:regexp}')${0}
+endsnippet
+
+snippet versioncmp "Version Compare Function" !b
+$${1:Variable} = versioncmp('${1:version}', '${2:version}')${0}
+endsnippet
+
+snippet warning "Warning Function" !b
+warning("${1:message}")${0}
 endsnippet
 
 # vim:ft=snippets:

--- a/bundle/ultisnips/UltiSnips/python.snippets
+++ b/bundle/ultisnips/UltiSnips/python.snippets
@@ -29,67 +29,81 @@ NORMAL  = 0x1
 DOXYGEN = 0x2
 SPHINX  = 0x3
 
+SINGLE_QUOTES = 0x1
+DOUBLE_QUOTES = 0x2
+
 def get_args(arglist):
-    args = [arg.split('=')[0].strip() for arg in arglist.split(',') if arg]
-    args = [arg for arg in args if arg and arg != "self"]
+	args = [arg.split('=')[0].strip() for arg in arglist.split(',') if arg]
+	args = [arg for arg in args if arg and arg != "self"]
 
-    return args
+	return args
 
+
+def get_quoting_style(snip):
+	style = snip.opt("g:ultisnips_python_quoting_style", "double")
+	if style == 'single':
+		return SINGLE_QUOTES
+	return DOUBLE_QUOTES
+
+def tripple_quotes(snip):
+	if get_quoting_style(snip) == SINGLE_QUOTES:
+		return "'''"
+	return '"""'
 
 def get_style(snip):
-    style = snip.opt("g:ultisnips_python_style", "normal")
+	style = snip.opt("g:ultisnips_python_style", "normal")
 
-    if    style == "doxygen": return DOXYGEN
-    elif  style == "sphinx": return SPHINX
-    else: return NORMAL
+	if    style == "doxygen": return DOXYGEN
+	elif  style == "sphinx": return SPHINX
+	else: return NORMAL
 
 
 def format_arg(arg, style):
-    if style == DOXYGEN:
-        return "@param %s @todo" % arg
-    elif style == SPHINX:
-        return ":param %s: @todo" % arg
-    elif style == NORMAL:
-        return ":%s: @todo" % arg
+	if style == DOXYGEN:
+		return "@param %s @todo" % arg
+	elif style == SPHINX:
+		return ":param %s: @todo" % arg
+	elif style == NORMAL:
+		return ":%s: @todo" % arg
 
 
 def format_return(style):
-    if style == DOXYGEN:
-        return "@return: @todo"
-    elif style in (NORMAL, SPHINX):
-        return ":returns: @todo"
+	if style == DOXYGEN:
+		return "@return: @todo"
+	elif style in (NORMAL, SPHINX):
+		return ":returns: @todo"
 
 
 def write_docstring_args(args, snip):
-    if not args:
-        snip.rv += ' """'
-        return
+	if not args:
+		snip.rv += ' {0}'.format(tripple_quotes(snip))
+		return
 
-    snip.rv += '\n' + snip.mkline('', indent='')
+	snip.rv += '\n' + snip.mkline('', indent='')
 
-    style = get_style(snip)
+	style = get_style(snip)
 
-    for arg in args:
-        snip += format_arg(arg, style)
+	for arg in args:
+		snip += format_arg(arg, style)
 
 
 def write_init_body(args, parents, snip):
-    parents = [p.strip() for p in parents.split(",")]
-    parents = [p for p in parents if p != 'object']
+	parents = [p.strip() for p in parents.split(",")]
+	parents = [p for p in parents if p != 'object']
 
-    for p in parents:
-        snip += p + ".__init__(self)"
+	for p in parents:
+		snip += p + ".__init__(self)"
 
-    if parents:
-        snip.rv += '\n' + snip.mkline('', indent='')
+	if parents:
+		snip.rv += '\n' + snip.mkline('', indent='')
 
-    for arg in args:
-        snip += "self._%s = %s" % (arg, arg)
+	for arg in args:
+		snip += "self._%s = %s" % (arg, arg)
 
 
 def write_slots_args(args, snip):
-    args = ['"%s"' % arg for arg in args]
-    snip += '__slots__ = (%s,)' % ', '.join(args)
+	args = ['"_%s"' % arg for arg in args]
+	snip += '__slots__ = (%s,)' % ', '.join(args)
 
 endglobal
 
@@ -99,10 +113,11 @@ endglobal
 
 snippet class "class with docstrings" b
 class ${1:MyClass}(${2:object}):
-	"""${3:Docstring for $1 }"""
+
+	`!p snip.rv = tripple_quotes(snip)`${3:Docstring for $1. }`!p snip.rv = tripple_quotes(snip)`
 
 	def __init__(self$4):
-		"""${5:@todo: to be defined}`!p
+		`!p snip.rv = tripple_quotes(snip)`${5:@todo: to be defined1.}`!p
 snip.rv = ""
 snip >> 2
 
@@ -110,8 +125,8 @@ args = get_args(t[4])
 
 write_docstring_args(args, snip)
 if args:
-    snip.rv += '\n' + snip.mkline('', indent='')
-    snip += '"""'
+	snip.rv += '\n' + snip.mkline('', indent='')
+	snip += '{0}'.format(tripple_quotes(snip))
 
 write_init_body(args, t[2], snip)
 `
@@ -121,7 +136,8 @@ endsnippet
 
 snippet slotclass "class with slots and docstrings" b
 class ${1:MyClass}(${2:object}):
-	"""${3:Docstring for $1 }"""
+
+	`!p snip.rv = tripple_quotes(snip)`${3:Docstring for $1. }`!p snip.rv = tripple_quotes(snip)`
 `!p
 snip >> 1
 args = get_args(t[4])
@@ -129,7 +145,7 @@ write_slots_args(args, snip)
 `
 
 	def __init__(self$4):
-		"""${5:@todo: to be defined}`!p
+		`!p snip.rv = tripple_quotes(snip)`${5:@todo: to be defined.}`!p
 snip.rv = ""
 snip >> 2
 
@@ -137,8 +153,8 @@ args = get_args(t[4])
 
 write_docstring_args(args, snip)
 if args:
-    snip.rv += '\n' + snip.mkline('', indent='')
-    snip += '"""'
+	snip.rv += '\n' + snip.mkline('', indent='')
+	snip += tripple_quotes(snip)
 
 write_init_body(args, t[2], snip)
 `
@@ -330,19 +346,19 @@ endsnippet
 snippet def "function with docstrings" b
 def ${1:function}(`!p
 if snip.indent:
-   snip.rv = 'self' + (", " if len(t[2]) else "")`${2:arg1}):
-	"""${4:@todo: Docstring for $1}`!p
+	snip.rv = 'self' + (", " if len(t[2]) else "")`${2:arg1}):
+	`!p snip.rv = tripple_quotes(snip)`${4:@todo: Docstring for $1.}`!p
 snip.rv = ""
 snip >> 1
 
 args = get_args(t[2])
 if args:
-   write_docstring_args(args, snip)
+	write_docstring_args(args, snip)
 
 style = get_style(snip)
 snip += format_return(style)
 snip.rv += '\n' + snip.mkline('', indent='')
-snip += '"""' `
+snip += tripple_quotes(snip) `
 	${0:pass}
 endsnippet
 
@@ -362,18 +378,57 @@ endsnippet
 ##############
 snippet roprop "Read Only Property" b
 @property
-def ${1:property}(self):
+def ${1:name}(self):
 	${2:return self._$1}$0
 endsnippet
 
 snippet rwprop "Read write property" b
-def ${1:property}():
-	${2/.+/(?0:""")/}${2:The RW property $1}${2/.+/(?0:"""\n		)/}def fget(self):
+def ${1:name}():
+	`!p snip.rv = tripple_quotes(snip) if t[2] else ''
+`${2:@todo: Docstring for $1.}`!p
+if t[2]:
+	snip >> 1
+
+	style = get_style(snip)
+	snip.rv += '\n' + snip.mkline('', indent='')
+	snip += format_return(style)
+	snip.rv += '\n' + snip.mkline('', indent='')
+	snip += tripple_quotes(snip)
+else:
+	snip.rv = ""`
+	def fget(self):
 		return self._$1$0
+
 	def fset(self, value):
 		self._$1 = value
 	return locals()
-$1 = property(**$1())
+
+$1 = property(**$1(), doc=$1.__doc__)
+endsnippet
+
+
+####################
+# If / Else / Elif #
+####################
+snippet if "If" b
+if ${1:condition}:
+	${2:pass}
+endsnippet
+
+snippet ife "If / Else" b
+if ${1:condition}:
+	${2:pass}
+else:
+	${3:pass}
+endsnippet
+
+snippet ifee "If / Elif / Else" b
+if ${1:condition}:
+	${2:pass}
+elif ${3:condition}:
+	${4:pass}
+else:
+	${5:pass}
 endsnippet
 
 
@@ -425,6 +480,14 @@ snippet pdb "Set PDB breakpoint" b
 import pdb; pdb.set_trace()
 endsnippet
 
+snippet ipdb "Set IPDB breakpoint" b
+import ipdb; ipdb.set_trace()
+endsnippet
+
+snippet pudb "Set PUDB breakpoint" b
+import pudb; pudb.set_trace()
+endsnippet
+
 snippet ae "Assert equal" b
 self.assertEqual(${1:first},${2:second})
 endsnippet
@@ -448,7 +511,8 @@ endsnippet
 
 snippet testcase "pyunit testcase" b
 class Test${1:Class}(${2:unittest.TestCase}):
-	"""${3:Test case docstring}"""
+
+	`!p snip.rv = tripple_quotes(snip)`${3:Test case docstring.}`!p snip.rv = tripple_quotes(snip)`
 
 	def setUp(self):
 		${4:pass}

--- a/bundle/ultisnips/UltiSnips/sh.snippets
+++ b/bundle/ultisnips/UltiSnips/sh.snippets
@@ -1,15 +1,32 @@
+global !p
+import vim
+
+# Tests for the existence of a variable declared by Vim's filetype detection
+# suggesting the type of shell script of the current file
+def testShell(scope, shell):
+    return vim.eval("exists('" + scope + ":is_" + shell + "')")
+
+# Loops over the possible variables, checking for global variables
+# first since they indicate an override by the user.
+def getShell():
+    for scope in ["g", "b"]:
+        for shell in ["bash", "sh", "kornshell"]:
+            if testShell(scope, shell) == "1":
+                if shell == "kornshell":
+                    return "ksh"
+                return shell
+    return "sh"
+endglobal
 
 ###########################################################################
 #                            TextMate Snippets                            #
 ###########################################################################
 snippet #!
-#!/bin/sh
-
+`!p snip.rv = '#!/bin/' + getShell() + "\n\n" `
 endsnippet
 
 snippet !env "#!/usr/bin/env (!env)"
-#!/usr/bin/env bash 
-
+`!p snip.rv = '#!/usr/bin/env ' + getShell() + "\n\n" `
 endsnippet
 
 snippet temp "Tempfile"

--- a/bundle/ultisnips/UltiSnips/tex.snippets
+++ b/bundle/ultisnips/UltiSnips/tex.snippets
@@ -4,7 +4,7 @@ extends texmath
 #                             LATEX SNIPPETS                              #
 ###########################################################################
 
-snippet r "\ref{}" w
+snippet r "\\ref{}" w
 \ref{$1}
 endsnippet
 
@@ -53,7 +53,7 @@ snippet desc "Description" b
 endsnippet
 
 #####################################
-# SECTIONS, CHAPTERS AND THERE LIKE #
+# SECTIONS, CHAPTERS AND THEIR LIKE #
 #####################################
 
 snippet part "Part" b
@@ -75,7 +75,7 @@ ${0}
 endsnippet
 
 snippet sec "Section" b
-\section{${1:section name}} 
+\section{${1:section name}}
 \label{sec:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/g}}}
 
 ${0}
@@ -122,4 +122,16 @@ ${0}
 % subparagraph $2 (end)
 endsnippet
 
+###############
+#  Utilities  #
+###############
+
+snippet pac "Package" b
+\usepackage[${1:options}]{${2:package}}$0
+endsnippet
+
+
+snippet lp "Long parenthesis" 
+\left(${1:${VISUAL:contents}}\right)$0
+endsnippet
 # vim:ft=snippets:

--- a/bundle/ultisnips/UltiSnips/xml.snippets
+++ b/bundle/ultisnips/UltiSnips/xml.snippets
@@ -1,0 +1,14 @@
+snippet xml "XML declaration" b
+<?xml version="1.0"?>
+
+endsnippet
+
+snippet t "Simple tag" b
+<${1:tag}>
+	${2:content}
+</${1/([\w:._-]+).*/$1/}>
+endsnippet
+
+snippet ti "Inline tag" b
+<${1:tag}>${2:content}</${1/([\w:._-]+).*/$1/}>
+endsnippet

--- a/bundle/ultisnips/UltiSnips/zsh.snippets
+++ b/bundle/ultisnips/UltiSnips/zsh.snippets
@@ -1,0 +1,13 @@
+extends sh
+
+snippet #! "shebang" !
+#!/bin/zsh
+
+endsnippet
+
+snippet !env "#!/usr/bin/env (!env)" !
+#!/usr/bin/env zsh
+
+endsnippet
+
+# vim:ft=snippets:

--- a/bundle/ultisnips/doc/UltiSnips.txt
+++ b/bundle/ultisnips/doc/UltiSnips.txt
@@ -11,11 +11,14 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
 3. Settings & Commands                          |UltiSnips-settings|
    3.1 Commands                                 |UltiSnips-commands|
    3.2 Triggers                                 |UltiSnips-triggers|
+      3.2.1 Using your own trigger functions    |UltiSnips-trigger-functions|
+      3.2.2 Path to Python Module               |UltiSnips-python-module-path|
    3.3 Snippet Search Path                      |UltiSnips-snippet-search-path|
    3.4 Warning About Select Mode Mappings       |UltiSnips-warning-smappings|
    3.5 Functions                                |UltiSnips-functions|
       3.5.1 UltiSnips_AddSnippet                |UltiSnips_AddSnippet|
       3.5.2 UltiSnips_Anon                      |UltiSnips_Anon|
+      3.5.3 UltiSnips_SnippetsInCurrentScope    |UltiSnips_SnippetsInCurrentScope|
    3.6 Missing python support                   |UltiSnips-python-warning|
 4. Syntax                                       |UltiSnips-syntax|
    4.1 Adding Snippets                          |UltiSnips-adding-snippets|
@@ -33,11 +36,12 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
       4.7.1 Replacement String                  |UltiSnips-replacement-string|
       4.7.2 Demos                               |UltiSnips-demos|
    4.8 Clearing snippets                        |UltiSnips-clearing-snippets|
-5. Helping Out                                  |UltiSnips-helping|
-6. Contact                                      |UltiSnips-contact|
-7. Contributors                                 |UltiSnips-contributors|
-   7.1 Patches & Coding                         |UltiSnips-contricoding|
-   7.2 Snippets                                 |UltiSnips-contrisnippets|
+5. Support for other plugins                    |UltiSnips-other-plugins|
+6. Helping Out                                  |UltiSnips-helping|
+7. Contact                                      |UltiSnips-contact|
+8. Contributors                                 |UltiSnips-contributors|
+   8.1 Patches & Coding                         |UltiSnips-contricoding|
+   8.2 Snippets                                 |UltiSnips-contrisnippets|
 
 This plugin only works if 'compatible' is not set.
 {Vi does not have any of these features}
@@ -84,11 +88,18 @@ They print '1' if the python version is compiled in, '0' if not.
 
 Test if Vim is compiled with python version 2.x: >
     :echo has("python")
+The python version Vim is linked against can be found with: >
+    :py import sys; print(sys.version)
 
 Test if Vim is compiled with python version 3.x: >
     :echo has("python3")
+The python version Vim is linked against can be found with: >
+    :py3 import sys; print(sys.version)
 
-UltiSnips attempts to autodetect which python version is compiled into Vim.
+Note that Vim is maybe not using your system-wide installed python version, so
+make sure to check the Python version inside of Vim.
+
+UltiSnips attempts to auto-detect which python version is compiled into Vim.
 Unfortunately, in some versions of Vim this detection does not work.
 In that case you have to explicitly tell UltiSnips which version to use using
 the 'UltiSnipsUsePythonVersion' global variable.
@@ -119,7 +130,7 @@ If you are a pathogen user, you can track the official mirror of UltiSnips on
 github: >
 
    $ cd ~/.vim/
-   $ git submodule add https://github.com/sirver/ultisnips bundle/ultisnips
+   $ git submodule add git://github.com/SirVer/ultisnips.git bundle/ultisnips
 
 See the pathogen documentation for more details on how to update a bundle.
 
@@ -138,6 +149,12 @@ Using bzr, checkout UltiSnips into a directory of your choice. >
 Then add this directory to your Vim runtime path by adding this line to your
 vimrc file. >
    set runtimepath+=~/.vim/ultisnips_rep
+
+UltiSnips also needs that Vim sources files from the ftdetect/ directory.
+Unfortunately, Vim only allows this directory in the .vim directory. You
+therefore have to symlink/copy the files: >
+   mkdir -p ~/.vim/ftdetect/
+   ln -s ~/.vim/ultisnips_rep/ftdetect/* ~/.vim/ftdetect/
 
 Restart Vim and UltiSnips should work. To access the help, use >
    :helptags ~/.vim/ultisnips_rep/doc
@@ -159,14 +176,14 @@ to runtimepath. See |UltiSnips-using-bzr| for an example.
 ------------
                                                              *:UltiSnipsEdit*
 The UltiSnipsEdit command opens the private snippet definition file for the
-current filetype for editing. If a definition file does not exist a new file
+current filetype for editing. If a definition file does not exist, a new file
 is opened with the appropriate name. Snippet definition files are standard
 text files and can be edited directly. UltiSnipsEdit makes it easier.
 
 There are several variables associated with the UltiSnipsEdit command.
 
                                                         *g:UltiSnipsEditSplit*
-g:UltiSnipsEditSplit        Defines how the edit window is open. Possible
+g:UltiSnipsEditSplit        Defines how the edit window is opened. Possible
                             values:
                             |normal|         Default. Opens in the current window.
                             |horizontal|     Splits the window horizontally.
@@ -182,7 +199,7 @@ g:UltiSnipsSnippetsDir
 
                                                        *:UltiSnipsAddFiletypes*
 The UltiSnipsAddFiletypes command allows for explicit merging of other snippet
-filetypes for the current buffer. For example if you edit a .rst file, but
+filetypes for the current buffer. For example, if you edit a .rst file but
 also want the Lua snippets to be available you can issue the command >
 
    :UltiSnipsAddFiletypes rst.lua
@@ -194,8 +211,8 @@ ftplugin/rails.vim >
 
    :UltiSnipsAddFiletypes rails.ruby
 
-I mention rails first, because I want to edit rails snippet when using
-UltiSnipsEdit and because rails snippet should overwrite equivalent ruby
+I mention rails first because I want to edit rails snippets when using
+UltiSnipsEdit and because rails snippets should overwrite equivalent ruby
 snippets. The priority will now be rails -> ruby -> all. If you have some
 special programming snippets that should have lower priority than your ruby
 snippets you can call >
@@ -223,13 +240,79 @@ vimrc file. >
    let g:UltiSnipsJumpForwardTrigger="<tab>"
    let g:UltiSnipsJumpBackwardTrigger="<s-tab>"
 
+3.2.1 Using your own trigger functions           *UltiSnips-trigger-functions*
+--------------------------------------
+
+For advanced users there are four functions that you can map directly to a
+key and that correspond to some of the triggers previously defined:
+   g:UltiSnipsExpandTrigger        <--> UltiSnips_ExpandSnippet
+   g:UltiSnipsJumpForwardTrigger   <--> UltiSnips_JumpForwards
+   g:UltiSnipsJumpBackwardTrigger  <--> UltiSnips_JumpBackwards
+
+If you have g:UltiSnipsExpandTrigger and g:UltiSnipsJumpForwardTrigger set
+to the same value then the function you are actually going to use is
+UltiSnips_ExpandSnippetOrJump.
+
+Each time any of the functions UltiSnips_ExpandSnippet,
+UltiSnips_ExpandSnippet, UltiSnips_JumpBackwards or UltiSnips_JumpBackwards is
+called a global variable is set that contains the return value of the
+corresponding function.
+
+The corresponding variables and functions are:
+UltiSnips_ExpandSnippet       --> g:ulti_expand_res (0: fail, 1: success)
+UltiSnips_ExpandSnippetOrJump --> g:ulti_expand_or_jump_res (0: fail,
+                                                    1: expand, 2: jump)
+UltiSnips_JumpForwards        --> g:ulti_jump_forwards_res (0: fail, 1: success)
+UltiSnips_JumpBackwards       --> g:ulti_jump_backwards_res (0: fail, 1: success)
+
+To see how these return values may come in handy, suppose that you want to map
+a key to expand or jump, but if none of these actions is successful you want
+to call another function. UltiSnips already does this automatically for
+supertab, but this allows you individual fine tuning of your Tab key usage.
+
+Usage is as follows: You define a function >
+
+   let g:ulti_expand_or_jump_res = 0 "default value, just set once
+   function! Ulti_ExpandOrJump_and_getRes()
+     call UltiSnips_ExpandSnippetOrJump()
+     return g:ulti_expand_or_jump_res
+   endfunction
+
+then you define your mapping as >
+
+   inoremap <NL> <C-R>=(Ulti_ExpandOrJump_and_getRes() > 0)?"":IMAP_Jumpfunc('', 0)<CR>
+
+and if the you can't expand or jump from the current location then the
+alternative function IMAP_Jumpfunc('', 0) is called.
+
+3.2.2 Path to Python module                   *UltiSnips-python-module-path*
+---------------------------
+
+For even more advanced usage, you can directly write python functions using
+UltiSnip's python modules.
+
+The path to UltiSnip's python implementation is stored in the
+g:UltiSnipsPythonPath variable which is set automatically on load.
+
+Here is a small example funtion that expands a snippet: >
+
+   function! s:Ulti_ExpandSnip()
+   Python << EOF
+   import sys, vim
+   new_path = vim.eval("expand('g:UltiSnipsPythonPath')")
+   sys.path.append(new_path)
+   from UltiSnips import UltiSnips_Manager
+   UltiSnips_Manager.expand()
+   EOF
+   return ""
+   endfunction
 
 3.3 Snippet Search Path                       *UltiSnips-snippet-search-path*
 -----------------------
 
 UltiSnips snippet definition files are stored in one or more directories.
-There are several variables used to indicate those directories and define how
-UltiSnips loads snippets.
+There are several variables used to indicate those directories and to define
+how UltiSnips loads snippets.
 
 Snippet definition files are stored in snippet directories. A snippet
 directory must be a subdirectory of a directory defined in the 'runtimepath'
@@ -247,6 +330,10 @@ with UltiSnips, add the following to your vimrc file. >
 If you do not want to use the snippets that come with UltiSnips, define the
 variable accordingly. >
    let g:UltiSnipsSnippetDirectories=["mycoolsnippets"]
+
+You can also redefine the search path on a buffer by buffer basis by setting
+the variable b:UltiSnipsSnippetDirectories.  This variable takes precedence
+over the global variable.
 
 UltiSnips searches in 'runtimepath' for snippet directories but traverses
 'runtimepath' in reverse order (last item first). If you would like to have
@@ -324,10 +411,55 @@ An example use case might be this line from a reStructuredText plugin file:
    inoremap <silent> $$ $$<C-R>=UltiSnips_Anon(':latex:\`$1\`', '$$')<cr>
 
 This expands the snippet whenever two $ signs are typed.
-Note: The right hand side of the mapping starts with an immediate retype of
+Note: The right-hand side of the mapping starts with an immediate retype of
 the '$$' trigger and passes '$$' to the function as the trigger argument.
 This is required in order for UltiSnips to have access to the characters
 typed so it can determine if the trigger matches or not.
+
+ 3.5.3 UltiSnips_SnippetsInCurrentScope    *UltiSnips_SnippetsInCurrentScope*
+
+A third function is UltiSnips_SnippetsInCurrentScope which is the equivalent
+of snipmate GetSnipsInCurrentScope function.
+This function simply returns a vim dictionary with the snippets whose trigger
+matches the current word.
+This function does not add any new functionality to ultisnips directly but
+allows to use third party plugins to integrate the current available snippets.
+
+An example of such third party plugin is SnippetCompleteSnipMate which uses
+the function GetSnipsInCurrentScope to integrate the current available
+snippets with user defined abbreviations and provides these and a completion
+menu.
+This script is located in
+http://www.vim.org/scripts/script.php?script_id=4276.
+Note: If you check the above website it lists two dependencies: the
+SnippetComplete plugin and snipmate.
+You do need the SnippetComplete plugin but you obviously don't need snipmate,
+you just have to define the function GetSnipsInCurrentScope. Put the following
+in your vimrc:
+
+function! GetSnipsInCurrentScope()
+  return UltiSnips_SnippetsInCurrentScope()
+endfunction
+
+
+As a second example on how to use this function consider the following
+function and mapping definition:
+
+function! ExpandPossibleShorterSnippet()
+  if len(UltiSnips_SnippetsInCurrentScope()) == 1 "only one candidate...
+    let curr_key = keys(UltiSnips_SnippetsInCurrentScope())[0]
+    normal diw
+    exe "normal a" . curr_key
+    exe "normal a "
+    return 1
+  endif
+  return 0
+endfunction
+inoremap <silent> <C-L> <C-R>=(ExpandPossibleShorterSnippet() == 0? '': UltiSnips_ExpandSnippet())<CR>
+
+If the trigger for your snippet is lorem, you type lor, and you have no other
+snippets whose trigger matches lor then hitting <C-L> will expand to whatever
+lorem expands to.
 
 
 3.6 Warning about missing python support           *UltiSnips-python-warning*
@@ -377,14 +509,17 @@ snippet filenames and their associated filetype.
 
 * The 'all' filetype is unique. It represents snippets available for use when
 editing any document regardless of the filetype. A date insertion snippet, for
-example, would be fit well in the all.snippets file.
+example, would fit well in the all.snippets file.
 
-UltiSnips supports Vim's dotted filetype syntax. To illustrate, the filetype
-for a cpp file could be set as follows ":set ft=cpp.c". If there exists
-c.snippets and cpp.c.snippets files in snippet directories snippets from both
-files are activated. CUDA files could have filetypes set to 'cuda.cpp.c'
-Snippets from all three, c.snippets, cpp.c.snippets and cuda.cpp.c.snippets
-are activated for that filetype.
+UltiSnips understands Vim's dotted filetype syntax. For example, if you define
+a dotted filetype for the CUDA C++ framework, e.g. ":set ft=cuda.cpp", then
+UltiSnips will search for and activate snippets for both the cuda and cpp
+filetypes.
+
+UltiSnips doesn't understand multiple filetypes in snippet filenames, so a
+snippet file named "cuda.cpp.snippets" won't match the "cuda" or "cpp"
+filetypes, which means it won't be activated for files with the dotted
+filetype "cuda.cpp" either.
 
 The extends directive provides an alternative way of combining snippet files.
 When the extends directive is included in a snippet file, it instructs
@@ -493,6 +628,10 @@ The options currently supported are: >
        replaced with spaces.) If this option is set, UltiSnips will ignore the
        Vim settings and insert the tab characters as is. This option is useful
        for snippets involved with tab delimited formats, for example.
+
+   s   Remove whitespace immediately before the cursor at the end of a line
+       before jumping to the next tabstop.  This is useful if there is a
+       tabstop with optional text at the end of a line.
 
 The end line is the 'endsnippet' keyword on a line by itself. >
 
@@ -642,7 +781,7 @@ endsnippet
 
  4.4.3 Python:                                             *UltiSnips-python*
 
-By far python interpolation is the most powerful. The syntax is similar to Vim
+Python interpolation is by far the most powerful. The syntax is similar to Vim
 scripts except code is started with '!p'. Python scripts can be run using the
 python shebang '#!/usr/bin/python', but using the '!p' format comes with some
 predefined objects and variables, which can simplify and shorten code. For
@@ -698,7 +837,7 @@ The 'snip' object provides some properties as well: >
     snip.v:
          Data related to the ${VISUAL} placeholder. The property has two
          attributes:
-             snip.v.mode   ('v', 'V', '^V', see *visual-mode* )
+             snip.v.mode   ('v', 'V', '^V', see |visual-mode| )
              snip.v.text   The text that was selected.
 
     snip.fn:
@@ -760,7 +899,7 @@ be center<tab> ->
 
 \end{center}
 
-The second form is a variation of the first, both produce the same result,
+The second form is a variation of the first; both produce the same result,
 but it illustrates how regular expression grouping works. Using regular
 expressions in this manner has some drawbacks:
 1. If you use the <Tab> key for both expanding snippets and completion then
@@ -1028,7 +1167,7 @@ The replacement string can contain $no variables, e.g., $1, which reference
 matched groups in the regular expression. The $0 variable is special and
 yields the whole match. The replacement string can also contain special escape
 sequences: >
-   \u   - Uppercase next letter;
+   \u   - Uppercase next letter
    \l   - Lowercase next letter
    \U   - Uppercase everything till the next \E
    \L   - Lowercase everything till the next \E
@@ -1124,10 +1263,27 @@ snippets if you wish to replace them. Simply use the '!' option. (See
 |UltiSnips-adding-snippets| for the options).
 
 
-=============================================================================
-5. Helping Out                                            *UltiSnips-helping*
+==============================================================================
+5. Support for other plugins             *UltiSnips-other-plugins*
 
-UltiSnips needs the help of the Vim community to make it better. Please
+UltiSnips has built-in support for some common plugins and there are others
+that are aware of UltiSnips and use it to improve the user experience. This is
+an incomplete list - if you want to have your plugin listed here, just sent me
+a pull request.
+
+Supertab - UltiSnips has built-in support for Supertab. Just use a recent
+enough version of both plugins and <tab> will either expand a snippet or defer
+to Supertab for expansion.
+
+neocomplcache - Stanislav Golovanov (JazzCore) has made an integration plugin
+to use UltiSnips as engine inside of neocomplcache. You can find his work at
+https://github.com/JazzCore/neocomplcache-ultisnips.
+
+
+=============================================================================
+6. Helping Out                                            *UltiSnips-helping*
+
+UltiSnips needs the help of the Vim community to keep improving. Please
 consider joining this effort by providing new snippets, new features or bug
 reports.
 
@@ -1150,11 +1306,11 @@ https://bugs.launchpad.net/ultisnips
 
 If you like this plugin, please vote for it on its Vim script page >
     http://www.vim.org/scripts/script.php?script_id=2715
-It is life changing for me. Maybe it is for you too.
+It is life-changing for me. Maybe it is for you too.
 
 
 =============================================================================
-6. Contact                                                *UltiSnips-contact*
+7. Contact                                                *UltiSnips-contact*
 
 You can reach me at SirVer -AT- gmx -ADOT- de. You can also contact me through
 the UltiSnips launchpad project page at https://launchpad.net/ultisnips/. The
@@ -1164,15 +1320,14 @@ bug tracker where you can report bugs and issues.
 This project aims to be the one-for-all solution for Snippets for Vim. If you
 miss a feature or find a bug, please contact me or file a support ticket.
 
-
 =============================================================================
-7. Contributors                                      *UltiSnips-contributors*
+8. Contributors                                      *UltiSnips-contributors*
 
 The primary developer of UltiSnips is SirVer (Holger Rapp). The following
 individuals have contributed code and snippets to UltiSnips.
 
 
-7.1 Patches & Coding                                 *UltiSnips-contricoding*
+8.1 Patches & Coding                                 *UltiSnips-contricoding*
 --------------------
 
 Contributors listed in chronological order:
@@ -1198,12 +1353,25 @@ Contributors listed in chronological order:
    iiijjjii - Jim Karsten
    fgalassi - Federico Galassi
    lucapette
-   Psycojoker - Laurent Peuch 
+   Psycojoker - Laurent Peuch
    aschrab - Aaron Schrab
-   NagatoPain (stardiviner)
+   stardiviner - NagatoPain
+   skeept - Jorge Rodrigues
+   buztard
+   stephenmckinney - Steve McKinney
+   Pedro Algarvio - s0undt3ch
+   Eric Van Dewoestine - ervandew
+   Matt Patterson - fidothe
+   Mike Morearty - mmorearty
+   Stanislav Golovanov - JazzCore
+   David Briscoe - DavidBriscoe
+   Keith Welch - paralogiki
+   Zhao Cai - zhaocai
+   John Szakmeister - jszakmeister
+   Jonas Diemer - diemer
 
 
-7.2 Snippets                                       *UltiSnips-contrisnippets*
+8.2 Snippets                                       *UltiSnips-contrisnippets*
 ------------
 
 Contributors listed in chronological order:
@@ -1216,7 +1384,7 @@ Contributors listed in chronological order:
    Georgi Valkov (gvalkov)
    Miek Gieben (miek)
    Aldis Berjoza (graudeejs)
-   Jorge (skeept)
+   Jorge Rodrigues (skeept)
    Martin Grenfell (scrooloose)
    Laughedelic
    Anthony Wilson (anthonywilson)
@@ -1229,6 +1397,31 @@ Contributors listed in chronological order:
    Jacek Wysocki (exu)
    Alexander Kondratskiy (KholdStare)
    Martin Krauskopf (martin-krauskopf)
+   Theocrite (theocrite)
+   Ferdinand Majerech (kiith-sa)
+   Vivien Didelot
+   Øystein Walle (osse)
+   Pedro Algarvio (s0undt3ch)
+   Steven Humphrey (shumphrey)
+   Björn Winckler (b4winckler)
+   David Brown (Nali4Freedom)
+   Harry Xu (harryxu)
+   Tom Cammann (takac)
+   Paolo Cretaro (melko)
+   Sergey Alexandrov (taketwo)
+   Jaromír Hradílek (jhradilek)
+   Vangelis Tsoumenis (kioopi)
+   Rudi Grinberg (rgrinberg)
+   javipolo
+   Matthew Strawbridge (pxc)
+   Josh Strater (jstrater)
+   jinzhu
+   Rene Vergara (ravl1084)
+   Johan Haals (JHaals)
+   Danilo Bargen (dbrgn)
+   Bernhard Vallant (lazerscience)
+   Von Welch (von)
+   Nikola Petrov (nikolavp)
 
 Thank you for your support.
 

--- a/bundle/ultisnips/doc/tags
+++ b/bundle/ultisnips/doc/tags
@@ -18,9 +18,11 @@ UltiSnips-helping	UltiSnips.txt	/*UltiSnips-helping*
 UltiSnips-installnupdate	UltiSnips.txt	/*UltiSnips-installnupdate*
 UltiSnips-interpolation	UltiSnips.txt	/*UltiSnips-interpolation*
 UltiSnips-mirrors	UltiSnips.txt	/*UltiSnips-mirrors*
+UltiSnips-other-plugins	UltiSnips.txt	/*UltiSnips-other-plugins*
 UltiSnips-placeholders	UltiSnips.txt	/*UltiSnips-placeholders*
 UltiSnips-plaintext-snippets	UltiSnips.txt	/*UltiSnips-plaintext-snippets*
 UltiSnips-python	UltiSnips.txt	/*UltiSnips-python*
+UltiSnips-python-module-path	UltiSnips.txt	/*UltiSnips-python-module-path*
 UltiSnips-python-warning	UltiSnips.txt	/*UltiSnips-python-warning*
 UltiSnips-replacement-string	UltiSnips.txt	/*UltiSnips-replacement-string*
 UltiSnips-requirements	UltiSnips.txt	/*UltiSnips-requirements*
@@ -30,6 +32,7 @@ UltiSnips-snippet-search-path	UltiSnips.txt	/*UltiSnips-snippet-search-path*
 UltiSnips-syntax	UltiSnips.txt	/*UltiSnips-syntax*
 UltiSnips-tabstops	UltiSnips.txt	/*UltiSnips-tabstops*
 UltiSnips-transformations	UltiSnips.txt	/*UltiSnips-transformations*
+UltiSnips-trigger-functions	UltiSnips.txt	/*UltiSnips-trigger-functions*
 UltiSnips-triggers	UltiSnips.txt	/*UltiSnips-triggers*
 UltiSnips-using-a-downloaded-packet	UltiSnips.txt	/*UltiSnips-using-a-downloaded-packet*
 UltiSnips-using-bzr	UltiSnips.txt	/*UltiSnips-using-bzr*
@@ -40,8 +43,8 @@ UltiSnips-warning-smappings	UltiSnips.txt	/*UltiSnips-warning-smappings*
 UltiSnips.txt	UltiSnips.txt	/*UltiSnips.txt*
 UltiSnips_AddSnippet	UltiSnips.txt	/*UltiSnips_AddSnippet*
 UltiSnips_Anon	UltiSnips.txt	/*UltiSnips_Anon*
+UltiSnips_SnippetsInCurrentScope	UltiSnips.txt	/*UltiSnips_SnippetsInCurrentScope*
 g:UltiSnipsEditSplit	UltiSnips.txt	/*g:UltiSnipsEditSplit*
 g:UltiSnipsSnippetsDir	UltiSnips.txt	/*g:UltiSnipsSnippetsDir*
 snippet	UltiSnips.txt	/*snippet*
 snippets	UltiSnips.txt	/*snippets*
-visual-mode	UltiSnips.txt	/*visual-mode*

--- a/bundle/ultisnips/ftplugin/snippets.vim
+++ b/bundle/ultisnips/ftplugin/snippets.vim
@@ -4,6 +4,10 @@
 setlocal foldmethod=syntax
 setlocal foldlevel=99
 
+setlocal commentstring=#%s
+
+setlocal noexpandtab
+
 " Define match words for use with matchit plugin
 " http://www.vim.org/scripts/script.php?script_id=39
 if exists("loaded_matchit") && !exists("b:match_words")

--- a/bundle/ultisnips/plugin/UltiSnips.vim
+++ b/bundle/ultisnips/plugin/UltiSnips.vim
@@ -3,7 +3,7 @@
 " Description: The Ultimate Snippets solution for Vim
 "
 " Testing Info: {{{
-"   See directions at the top of the test.py script located one 
+"   See directions at the top of the test.py script located one
 "   directory above this file.
 " }}}
 
@@ -46,13 +46,13 @@ if !exists("g:UltiSnipsExpandTrigger")
     let g:UltiSnipsExpandTrigger = "<tab>"
 endif
 
-" The trigger used to display all triggers that could possible 
+" The trigger used to display all triggers that could possible
 " match in the current position.
 if !exists("g:UltiSnipsListSnippets")
     let g:UltiSnipsListSnippets = "<c-tab>"
 endif
 
-" The trigger used to jump forward to the next placeholder. 
+" The trigger used to jump forward to the next placeholder.
 " NOTE: expansion and forward jumping can, but needn't be the same trigger
 if !exists("g:UltiSnipsJumpForwardTrigger")
     let g:UltiSnipsJumpForwardTrigger = "<c-j>"
@@ -80,7 +80,7 @@ if !exists("g:UltiSnipsEditSplit")
     let g:UltiSnipsEditSplit = 'normal'
 endif
 
-" A list of directory names that are searched for snippets. 
+" A list of directory names that are searched for snippets.
 if !exists("g:UltiSnipsSnippetDirectories")
     let g:UltiSnipsSnippetDirectories = [ "UltiSnips" ]
 endif
@@ -107,7 +107,8 @@ function! UltiSnipsEdit(...)
 endfunction
 
 " edit snippets, default of current file type or the specified type
-command! -nargs=? UltiSnipsEdit :call UltiSnipsEdit(<q-args>)
+command! -nargs=? -complete=customlist,UltiSnipsFiletypeComplete UltiSnipsEdit
+    \ :call UltiSnipsEdit(<q-args>)
 
 " Global Commands {{{
 function! UltiSnipsAddFiletypes(filetypes)
@@ -142,6 +143,12 @@ endfunction
 function! UltiSnips_ListSnippets()
     exec g:_uspy "UltiSnips_Manager.list_snippets()"
     return ""
+endfunction
+
+function! UltiSnips_SnippetsInCurrentScope()
+    let g:current_ulti_dict = {}
+    exec g:_uspy "UltiSnips_Manager.list_snippets_dict()"
+    return g:current_ulti_dict
 endfunction
 
 function! UltiSnips_SaveLastVisualSelection()
@@ -207,6 +214,8 @@ function! UltiSnips_MapKeys()
     exec "snoremap <silent> " . g:UltiSnipsListSnippets . " <Esc>:call UltiSnips_ListSnippets()<cr>"
 
     snoremap <silent> <BS> <c-g>c
+    snoremap <silent> <DEL> <c-g>c
+    snoremap <silent> <c-h> <c-g>c
 endf
 
 function! UltiSnips_CursorMoved()
@@ -219,12 +228,31 @@ function! UltiSnips_LeavingBuffer()
     exec g:_uspy "UltiSnips_Manager.leaving_buffer()"
 endf
 " }}}
+" COMPLETE FUNCTIONS {{{
+function! UltiSnipsFiletypeComplete(arglead, cmdline, cursorpos)
+    let ret = {}
+    let items = map(
+    \   split(globpath(&runtimepath, 'syntax/*.vim'), '\n'),
+    \   'fnamemodify(v:val, ":t:r")'
+    \ )
+    call insert(items, 'all')
+    for item in items
+        if !has_key(ret, item) && item =~ '^'.a:arglead
+            let ret[item] = 1
+        endif
+    endfor
+
+    return sort(keys(ret))
+endfunction
+
+" }}}
 
 "" STARTUP CODE {{{
 
 " Expand our path
 exec g:_uspy "import vim, os, sys"
 exec g:_uspy "new_path = vim.eval('expand(\"<sfile>:h\")')"
+exec g:_uspy "vim.command(\"let g:UltiSnipsPythonPath = '%s'\" % new_path)"
 exec g:_uspy "sys.path.append(new_path)"
 exec g:_uspy "from UltiSnips import UltiSnips_Manager"
 exec g:_uspy "UltiSnips_Manager.expand_trigger = vim.eval('g:UltiSnipsExpandTrigger')"

--- a/bundle/ultisnips/plugin/UltiSnips/__init__.py
+++ b/bundle/ultisnips/plugin/UltiSnips/__init__.py
@@ -288,6 +288,10 @@ class Snippet(object):
             return match
         return False
 
+    def has_option(self, opt):
+        """ Check if the named option is set """
+        return opt in self._opts
+
     def matches(self, trigger):
         # If user supplies both "w" and "i", it should perhaps be an
         # error, but if permitted it seems that "w" should take precedence
@@ -412,12 +416,8 @@ class Snippet(object):
             v.append(line_ind + line[tabs:])
         v = '\n'.join(v)
 
-        if parent is None:
-            si = SnippetInstance(None, indent, v, start, end, visual_content = visual_content,
-                    last_re = self._last_re, globals = self._globals)
-        else:
-            si = SnippetInstance(parent, indent, v, start, end, visual_content,
-                    last_re = self._last_re, globals = self._globals)
+        si = SnippetInstance(self, parent, indent, v, start, end, visual_content,
+                last_re = self._last_re, globals = self._globals)
 
         return si
 
@@ -526,23 +526,55 @@ class SnippetManager(object):
 
     @err_to_scratch_buffer
     def jump_forwards(self):
+        _vim.command("let g:ulti_jump_forwards_res = 1")
         if not self._jump():
+            _vim.command("let g:ulti_jump_forwards_res = 0")
             return self._handle_failure(self.forward_trigger)
 
     @err_to_scratch_buffer
     def jump_backwards(self):
+        _vim.command("let g:ulti_jump_backwards_res = 1")
         if not self._jump(True):
+            _vim.command("let g:ulti_jump_backwards_res = 0")
             return self._handle_failure(self.backward_trigger)
 
     @err_to_scratch_buffer
     def expand(self):
+        _vim.command("let g:ulti_expand_res = 1")
         if not self._try_expand():
+            _vim.command("let g:ulti_expand_res = 0")
             self._handle_failure(self.expand_trigger)
+
+    @err_to_scratch_buffer
+    def list_snippets_dict(self):
+        before, after = _vim.buf.current_line_splitted
+        snippets = self._snips(before, True)
+
+        # Sort snippets alphabetically
+        snippets.sort(key=lambda x: x.trigger)
+        for snip in snippets:
+            description = snip.description[snip.description.find(snip.trigger) +
+                len(snip.trigger) + 2:]
+
+            key = as_unicode(snip.trigger)
+            description = as_unicode(description)
+
+            #remove surrounding "" or '' in snippet description if it exists
+            if len(description) > 2:
+              if description[0] == description[-1] and description[0] in ['"', "'"]:
+                description = description[1:-1]
+
+            _vim.command(as_unicode("let g:current_ulti_dict['{key}'] = '{val}'").format(
+              key=key.replace("'", "''"), val=description.replace("'", "''")))
 
     @err_to_scratch_buffer
     def list_snippets(self):
         before, after = _vim.buf.current_line_splitted
         snippets = self._snips(before, True)
+
+        if len(snippets) == 0:
+            self._handle_failure(self.backward_trigger)
+            return True
 
         # Sort snippets alphabetically
         snippets.sort(key=lambda x: x.trigger)
@@ -566,10 +598,13 @@ class SnippetManager(object):
         expansion and forward jumping. It first tries to expand a snippet, if
         this fails, it tries to jump forward.
         """
+        _vim.command('let g:ulti_expand_or_jump_res = 1')
         rv = self._try_expand()
         if not rv:
+            _vim.command('let g:ulti_expand_or_jump_res = 2')
             rv = self._jump()
         if not rv:
+            _vim.command('let g:ulti_expand_or_jump_res = 0')
             self._handle_failure(self.expand_trigger)
 
     @err_to_scratch_buffer
@@ -734,6 +769,14 @@ class SnippetManager(object):
         if self._cs:
             self._ctab = self._cs.select_next_tab(backwards)
             if self._ctab:
+                before, after = _vim.buf.current_line_splitted
+                if self._cs.snippet.has_option("s"):
+                    if after == "":
+                        m = re.match(r'(.*?)\s+$', before)
+                        if m:
+                            lineno = _vim.buf.cursor.line
+                            _vim.text_to_vim(Position(lineno,0), Position(
+                                lineno,len(before)+len(after)), m.group(1))
                 _vim.select(self._ctab.start, self._ctab.end)
                 jumped = True
                 if self._ctab.no == 0:
@@ -754,6 +797,8 @@ class SnippetManager(object):
         """
         if trigger.lower() == "<tab>":
             feedkey = "\\" + trigger
+        elif trigger.lower() == "<s-tab>":
+            feedkey = "\\" + trigger
         else:
             feedkey = None
         mode = "n"
@@ -769,15 +814,18 @@ class SnippetManager(object):
         for idx, sttrig in enumerate(self._supertab_keys):
             if trigger.lower() == sttrig.lower():
                 if idx == 0:
-                    feedkey= r"\<c-n>"
+                    feedkey= r"\<Plug>SuperTabForward"
+                    mode = "n"
                 elif idx == 1:
-                    feedkey = r"\<c-p>"
+                    feedkey = r"\<Plug>SuperTabBackward"
+                    mode = "p"
                 # Use remap mode so SuperTab mappings will be invoked.
-                mode = "m"
                 break
 
-        if feedkey:
-            _vim.feedkeys(feedkey, mode)
+        if feedkey == r"\<Plug>SuperTabForward" or feedkey == r"\<Plug>SuperTabBackward":
+            _vim.command("return SuperTab(%s)" % _vim.escape(mode))
+        elif feedkey:
+            _vim.command("return %s" % _vim.escape(feedkey))
 
     def _snips(self, before, possible):
         """ Returns all the snippets for the given text
@@ -839,6 +887,17 @@ class SnippetManager(object):
             start = Position(_vim.buf.cursor.line, len(text_before))
             end = Position(_vim.buf.cursor.line, len(before))
 
+            # It could be that our trigger contains the content of TextObjects
+            # in our containing snippet. If this is indeed the case, we have to
+            # make sure that those are properly killed. We do this by
+            # pretending that the user deleted and retyped the text that our
+            # trigger matched.
+            edit_actions = [
+                ("D", start.line, start.col, snippet.matched),
+                ("I", start.line, start.col, snippet.matched),
+            ]
+            self._csnippets[0].replay_user_edits(edit_actions)
+
             si = snippet.launch(text_before, self._visual_content,
                     self._cs.find_parent_for_new_to(start), start, end)
         else:
@@ -895,7 +954,10 @@ class SnippetManager(object):
         the filetype.
         """
 
-        snippet_dirs = _vim.eval("g:UltiSnipsSnippetDirectories")
+        if _vim.eval("exists('b:UltiSnipsSnippetDirectories')") == "1":
+            snippet_dirs = _vim.eval("b:UltiSnipsSnippetDirectories")
+        else:
+            snippet_dirs = _vim.eval("g:UltiSnipsSnippetDirectories")
         base_snippets = os.path.realpath(os.path.join(__file__, "../../../UltiSnips"))
         ret = []
 

--- a/bundle/ultisnips/plugin/UltiSnips/_vim.py
+++ b/bundle/ultisnips/plugin/UltiSnips/_vim.py
@@ -80,7 +80,7 @@ def text_to_vim(start, end, text):
 
     # Open any folds this might have created
     buf.cursor = start
-    vim.command("normal zv")
+    vim.command("normal! zv")
 
     return new_end
 

--- a/bundle/ultisnips/plugin/UltiSnips/debug.py
+++ b/bundle/ultisnips/plugin/UltiSnips/debug.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-__all__ = [ "debug" ]
+__all__ = [ "debug", "echo_to_hierarchy", "print_stack" ]
 
 import sys
 
 from UltiSnips.compatibility import as_unicode
+
+dump_filename = "/tmp/file.txt" if not sys.platform.lower().startswith("win") \
+        else "C:/windows/temp/ultisnips.txt"
+with open(dump_filename, "w") as dump_file:
+    pass # clears the file
 
 def echo_to_hierarchy(to):
     par = to
@@ -24,10 +29,11 @@ def echo_to_hierarchy(to):
 
 def debug(s):
     s = as_unicode(s)
-    fn = "/tmp/file.txt" if not sys.platform.lower().startswith("win") \
-            else "C:/windows/temp/ultisnips.txt"
-    f = open(fn,"ab")
-    f.write((s + '\n').encode("utf-8"))
-    f.close()
+    with open(dump_filename, "ab") as dump_file:
+        dump_file.write((s + '\n').encode("utf-8"))
 
+def print_stack():
+    import traceback
+    with open(dump_filename, "ab") as dump_file:
+        traceback.print_stack(file=dump_file)
 

--- a/bundle/ultisnips/plugin/UltiSnips/text_objects/_python_code.py
+++ b/bundle/ultisnips/plugin/UltiSnips/text_objects/_python_code.py
@@ -2,7 +2,6 @@
 # encoding: utf-8
 
 import os
-import re
 from collections import namedtuple
 
 import UltiSnips._vim as _vim
@@ -10,6 +9,7 @@ from UltiSnips.compatibility import compatible_exec, as_unicode
 from UltiSnips.util import IndentUtil
 
 from UltiSnips.text_objects._base import NoneditableTextObject
+
 
 class _Tabs(object):
     def __init__(self, to):
@@ -22,6 +22,8 @@ class _Tabs(object):
         return ts.current_text
 
 _VisualContent = namedtuple('_VisualContent', ['mode', 'text'])
+
+
 class SnippetUtil(object):
     """ Provides easy access to indentation, etc.
     """
@@ -65,7 +67,7 @@ class SnippetUtil(object):
         try:
             self.indent = self.indent[:by]
         except IndexError:
-            indent = ""
+            self.indent = ""
 
     def mkline(self, line="", indent=None):
         """ Creates a properly set up line.
@@ -74,7 +76,7 @@ class SnippetUtil(object):
         :indent: the indentation to have at the beginning
                  if None, it uses the default amount
         """
-        if indent == None:
+        if indent is None:
             indent = self.indent
             # this deals with the fact that the first line is
             # already properly indented
@@ -117,6 +119,7 @@ class SnippetUtil(object):
         """
         def fget(self):
             return self._rv
+
         def fset(self, value):
             self._changed = True
             self._rv = value
@@ -153,7 +156,7 @@ class SnippetUtil(object):
     # Syntatic sugar
     def __add__(self, value):
         """ Appends the given line to rv using mkline. """
-        self.rv += '\n' # handles the first line properly
+        self.rv += '\n'  # handles the first line properly
         self.rv += self.mkline(value)
         return self
 
@@ -207,17 +210,17 @@ class PythonCode(NoneditableTextObject):
             'path': path,
             'cur': ct,
             'res': ct,
-            'snip' : self._snip,
+            'snip': self._snip,
         })
 
         compatible_exec(self._code, self._globals, local_d)
 
-        rv = as_unicode(self._snip.rv if self._snip._rv_changed
-                else as_unicode(local_d['res']))
+        rv = as_unicode(
+            self._snip.rv if self._snip._rv_changed
+            else as_unicode(local_d['res'])
+        )
 
         if ct != rv:
             self.overwrite(rv)
             return False
         return True
-
-

--- a/bundle/ultisnips/plugin/UltiSnips/text_objects/_shell_code.py
+++ b/bundle/ultisnips/plugin/UltiSnips/text_objects/_shell_code.py
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 import os
+import platform
 import subprocess
 import stat
 import tempfile
@@ -9,34 +10,59 @@ import tempfile
 from UltiSnips.compatibility import as_unicode
 from UltiSnips.text_objects._base import NoneditableTextObject
 
+def _chomp(string):
+    """Rather than rstrip(), remove only the last newline and preserve purposeful whitespace"""
+    if len(string) and string[-1] == '\n':
+        string = string[:-1]
+    if len(string) and string[-1] == '\r':
+        string = string[:-1]
+    return string
+
+def _run_shell_command(cmd, tmpdir):
+    """Write the code to a temporary file"""
+    cmdsuf = ''
+    if platform.system() == 'Windows':
+        # suffix required to run command on windows
+        cmdsuf = '.bat'
+        # turn echo off
+        cmd = '@echo off\r\n' + cmd
+    handle, path = tempfile.mkstemp(text=True, dir=tmpdir, suffix=cmdsuf)
+    os.write(handle, cmd.encode("utf-8"))
+    os.close(handle)
+    os.chmod(path, stat.S_IRWXU)
+
+    # Execute the file and read stdout
+    proc = subprocess.Popen(path, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc.wait()
+    stdout, stderr = proc.communicate()
+
+    os.unlink(path)
+    return _chomp(stdout.encode('utf-8'))
+
+def _get_tmp():
+    """Find an executable tmp directory"""
+    userdir = os.path.expanduser("~")
+    for testdir in [tempfile.gettempdir(), os.path.join(userdir, '.cache'), os.path.join(userdir, '.tmp'), userdir]:
+        if not os.path.exists(testdir) or not _run_shell_command('echo success', testdir) == 'success':
+            continue
+        return testdir
+    return ''
+
 class ShellCode(NoneditableTextObject):
     def __init__(self, parent, token):
         NoneditableTextObject.__init__(self, parent, token)
 
         self._code = token.code.replace("\\`", "`")
+        self._tmpdir = _get_tmp()
 
     def _update(self, done, not_done):
-        # Write the code to a temporary file
-        handle, path = tempfile.mkstemp(text=True)
-        os.write(handle, self._code.encode("utf-8"))
-        os.close(handle)
-        os.chmod(path, stat.S_IRWXU)
-
-        # Execute the file and read stdout
-        proc = subprocess.Popen(path, shell=True, stdout=subprocess.PIPE)
-        proc.wait()
-        output = as_unicode(proc.stdout.read())
-
-        if len(output) and output[-1] == '\n':
-            output = output[:-1]
-        if len(output) and output[-1] == '\r':
-            output = output[:-1]
-
-        os.unlink(path)
+        if not self._tmpdir:
+            output = "Unable to find executable tmp directory, check noexec on /tmp"
+        else:
+            output = _run_shell_command(self._code, self._tmpdir)
 
         self.overwrite(output)
         self._parent._del_child(self)
 
         return True
-
 

--- a/bundle/ultisnips/plugin/UltiSnips/text_objects/_snippet_instance.py
+++ b/bundle/ultisnips/plugin/UltiSnips/text_objects/_snippet_instance.py
@@ -15,12 +15,12 @@ class SnippetInstance(EditableTextObject):
     also a TextObject because it has a start an end
     """
 
-    def __init__(self, parent, indent, initial_text, start, end, visual_content, last_re, globals):
+    def __init__(self, snippet, parent, indent, initial_text, start, end, visual_content, last_re, globals):
         if start is None:
             start = Position(0,0)
         if end is None:
             end = Position(0,0)
-
+        self.snippet = snippet
         self._cts = 0
 
         self.locals = {"match" : last_re}
@@ -74,7 +74,6 @@ class SnippetInstance(EditableTextObject):
             raise RuntimeError("The snippets content did not converge: Check for Cyclic dependencies "
                 "or random strings in your snippet. You can use 'if not snip.c' to make sure "
                 "to only expand random output once.")
-
         vc.to_vim()
         self._del_child(vc)
 
@@ -118,7 +117,7 @@ class _VimCursor(NoneditableTextObject):
 
     def __init__(self, parent):
         NoneditableTextObject.__init__(
-            self, parent, _vim.buf.cursor, _vim.buf.cursor, tiebreaker = Position(0,0),
+            self, parent, _vim.buf.cursor, _vim.buf.cursor, tiebreaker = Position(-1,-1),
         )
 
     def to_vim(self):

--- a/bundle/ultisnips/syntax/snippets.vim
+++ b/bundle/ultisnips/syntax/snippets.vim
@@ -12,16 +12,17 @@ syntax include @Viml syntax/vim.vim
 syn match snipComment "^#.*" contains=snipTODO
 syn keyword snipTODO FIXME NOTE NOTES TODO XXX contained
 
+syn match snipDocString '"[^"]*"$'
 syn match snipString '"[^"]*"'
 syn match snipTabsOnly "^\t\+$"
 
-syn match snipKeyword "\(\<\(end\)\?\(snippet\|global\)\>\)\|extends" contained
+syn match snipKeyword "\(\<\(end\)\?\(snippet\|global\)\>\)\|extends\|clearsnippets" contained
 
 " extends definitions
 syn match snipExtends "^extends.*" contains=snipKeyword
 
 " snippet definitions
-syn match snipStart "^snippet.*" contained contains=snipKeyword,snipString
+syn match snipStart "^snippet.*" contained contains=snipKeyword,snipDocString
 syn match snipEnd "^endsnippet" contained contains=snipKeyword
 syn region snipCommand contained keepend start="`" end="`" contains=snipPythonCommand,snipVimLCommand
 syn region snipPythonCommand contained keepend start="`!p" end="`" contained contains=@Python
@@ -36,10 +37,14 @@ syn match snipGlobalStart "^global.*" contained contains=snipKeyword,snipString
 syn match snipGlobalEnd "^endglobal" contained contains=snipKeyword
 syn region snipGlobal fold keepend start="^global" end="^endglobal" contains=snipGlobalStart,snipGlobalEnd,snipTabsOnly,snipCommand,snipVarExpansion,snipVar,@Python
 
+" snippet clearing
+syn match snipClear "^clearsnippets"
+
 " highlighting rules
 
 hi link snipComment      Comment
 hi link snipString       String
+hi link snipDocString    String
 hi link snipTabsOnly     Error
 
 hi link snipKeyword      Keyword
@@ -57,5 +62,7 @@ hi link snippet          Normal
 hi link snipGlobalStart  Statement
 hi link snipGlobalEnd    Statement
 hi link snipGlobal       Normal
+
+hi link snipClear        Statement
 
 let b:current_syntax = "snippet"

--- a/bundle/ultisnips/utils/convert_snipmate_snippets.py
+++ b/bundle/ultisnips/utils/convert_snipmate_snippets.py
@@ -22,9 +22,9 @@ def convert_snippet_file(source):
         # Ignore empty lines
         if line.strip() == "":
             continue
-        # The rest of the handlig is stateful
+        # The rest of the handling is stateful
         if state == 0:
-            # Find snippet start
+            # Find snippet start. Keep comments.
             if line[:8] == "snippet ":
                 snippet_info = re.match("(\S+)\s*(.*)", line[8:])
                 if not snippet_info:
@@ -33,6 +33,9 @@ def convert_snippet_file(source):
                 retval += 'snippet %s "%s"' % (snippet_info.group(1), snippet_info.group(2) if snippet_info.group(2) else snippet_info.group(1)) + "\n"
                 state = 1
                 snippet = ""
+            elif line[:1] == "#":
+                retval += line
+                state = 0
         elif state == 1:
             # First line of snippet: Get indentation
             whitespace = re.search("^\s+", line)
@@ -45,10 +48,12 @@ def convert_snippet_file(source):
                 snippet += line[len(whitespace):]
                 state = 2
         elif state == 2:
-            # In snippet: Check if indentation level is the same. If not, snippet has ended
-            if line[:len(whitespace)] != whitespace:
+            # In snippet: If indentation level is the same, add to snippet. Else end snippet.
+            if line[:len(whitespace)] == whitespace:
+                snippet += line[len(whitespace):]
+            else:
                 retval += convert_snippet_contents(snippet) + "endsnippet\n\n"
-                # Copy-paste the section from state=0 so that we don't skip every other snippet
+                #Copy-paste the section from state=0 so that we don't skip every other snippet
                 if line[:8] == "snippet ":
                     snippet_info = re.match("(\S+)\s*(.*)", line[8:])
                     if not snippet_info:
@@ -57,8 +62,9 @@ def convert_snippet_file(source):
                     retval += 'snippet %s "%s"' % (snippet_info.group(1), snippet_info.group(2) if snippet_info.group(2) else snippet_info.group(1)) + "\n"
                     state = 1
                     snippet = ""
-            else:
-                snippet += line[len(whitespace):]
+                elif line[:1] == "#":
+                    retval += line
+                    state = 0
     if state == 2:
         retval += convert_snippet_contents(snippet) + "endsnippet\n\n"
     return retval
@@ -85,12 +91,18 @@ if __name__ == '__main__':
     argsp.add_argument("target", help="File to write the resulting snippets into. If omitted, the snippets will be written to stdout.", nargs="?", default="-")
     args = argsp.parse_args()
 
-    source = args.source
+    source_file_name = args.source
+    tmp_file_name = ''.join([args.target,'.tmp'])
     try:
-        target = sys.stdout if args.target == "-" else open(args.target, "w")
+        tmp = sys.stdout if args.target == "-" else open(tmp_file_name, "w")
     except IOError:
-        print >> sys.stderr, "Error: Failed to open output file %s for writing" % args.target
+        print >> sys.stderr, "Error: Failed to open output file %s for writing" % tmp_file_name
         sys.exit(1)
 
-    snippets = convert_snippets(source)
-    print >> target, snippets
+    snippets = convert_snippets(source_file_name)
+    print >> tmp, snippets
+
+    if args.target != "-":
+        if os.access(args.target, os.F_OK):
+            os.remove(args.target)
+        os.rename(tmp_file_name, args.target)

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -1743,7 +1743,8 @@ scripts is used to define snippets.  For example, the file
 ~/.vim/UltiSnips/c.snippets.  All snippets make be "built" via the Makefile in
 ~/.vim/UltiSnips by executing "make".
 
-Version 2.2 from http://www.vim.org/scripts/script.php?script_id=2715
+Version 84c36fccd88d6ddbc73f62abfd7f3e56523422e9 from
+git://github.com/SirVer/ultisnips.git
 
 Installation:
 - Follow bundle installation instructions (|bundle_installation|).

--- a/vimrc
+++ b/vimrc
@@ -2170,32 +2170,6 @@ function! SetLocalSnippetDirectories(ultiSnipsSnippetDirectories)
     let b:UltiSnipsSnippetDirectories = a:ultiSnipsSnippetDirectories
 endfunction
 
-" Until UltiSnips acquires a method for setting buffer-local snippets paths,
-" the auto-commands below fake this feature by saving the global value of
-" g:UltiSnipsSnippetDirectories when entering a buffer and changing it to a
-" buffer-local setting, then restoring from the saved value when leaving the
-" buffer.
-
-" Save g:UltiSnipsSnippetDirectories when entering a buffer, and switch
-" g:UltiSnipsSnippetDirectories to a buffer-local value (if it exists).
-function! AutoEnterUltiSnipsBuffer()
-    let b:SavedUltiSnipsSnippetDirectories = g:UltiSnipsSnippetDirectories
-    if exists("b:UltiSnipsSnippetDirectories")
-        let g:UltiSnipsSnippetDirectories = b:UltiSnipsSnippetDirectories
-    endif
-endfunction
-
-" Restore g:UltiSnipsSnippetDirectories from saved value.
-function! AutoLeaveUltiSnipsBuffer()
-    " If somehow an autocmd got skipped and there is no saved value,
-    " revert to UltiSnip default value.
-    if exists("b:UltiSnipsSnippetDirectories")
-        let g:UltiSnipsSnippetDirectories = b:SavedUltiSnipsSnippetDirectories
-    else
-        let g:UltiSnipsSnippetDirectories = ["UltiSnips"]
-    endif
-endfunction
-
 " Helper to be called from your .lvimrc.
 function! AppendSnippetDirs(snippetDirs)
     if type(a:snippetDirs) == type([])
@@ -2204,12 +2178,6 @@ function! AppendSnippetDirs(snippetDirs)
         let b:UltiSnipsSnippetDirectories += [a:snippetDirs]
     endif
 endfunction
-
-augroup local_ultiSnips
-    autocmd!
-    autocmd BufEnter * call AutoEnterUltiSnipsBuffer()
-    autocmd BufLeave * call AutoLeaveUltiSnipsBuffer()
-augroup END
 
 " -------------------------------------------------------------
 " vis


### PR DESCRIPTION
While trying to support templates for new buffers, I discovered that the
UltiSnips_SnippetsInCurrentScope() function was busted when the
description contained an apostrophe.  My fix was incorporated upstream,
and this version contains that fix.  The new version also contains
support for buffer local snippet directories, so this removes the
autocmd workaround we had in place.
