### PR TITLE
Update tagbar to a newer version.

### DIFF
--- a/bundle/tagbar/README.md
+++ b/bundle/tagbar/README.md
@@ -5,6 +5,9 @@ It provides a sidebar that displays the ctags-generated tags of the current file
 
 Check out the homepage at http://majutsushi.github.com/tagbar/ for more information.
 
+# Support for additional filetypes
+
+For filetypes that are not supported by Exuberant Ctags check out [the wiki](https://github.com/majutsushi/tagbar/wiki) to see whether other projects offer support for them and how to use them. Please add any other projects/configurations that you find or create yourself so that others can benefit from them, too.
 
 # Important: If the file structure is displayed wrong
 

--- a/bundle/tagbar/doc/tagbar.txt
+++ b/bundle/tagbar/doc/tagbar.txt
@@ -261,7 +261,8 @@ COMMANDS                                                     *tagbar-commands*
     Close the Tagbar window if it is open.
 
 :TagbarToggle                                                  *:TagbarToggle*
-    Open the Tagbar window if it is closed or close it if it is open.
+:Tagbar
+    Open the Tagbar window if it is closed, or close it if it is open.
 
 :TagbarOpenAutoClose                                    *:TagbarOpenAutoClose*
     Open the Tagbar window, jump to it and close it on tag selection. This is
@@ -298,6 +299,8 @@ COMMANDS                                                     *tagbar-commands*
     Start debug mode. This will write debug messages to file [logfile] while
     using Tagbar. If no argument is given "tagbardebug.log" in the current
     directory is used. Note: an existing file will be overwritten!
+    Note also that it is usually necessary to call this command before loading
+    a file that creates problems in order to get all of the needed data.
 
 :TagbarDebugEnd                                              *:TagbarDebugEnd*
     End debug mode, debug messages will no longer be written to the logfile.
@@ -308,27 +311,51 @@ KEY MAPPINGS                                                     *tagbar-keys*
 The following mappings are valid in the Tagbar window:
 
 <F1>          Display key mapping help.
+                Map option: tagbar_map_help
 <CR>/<Enter>  Jump to the tag under the cursor. Doesn't work for pseudo-tags
               or generic headers.
+                Map option: tagbar_map_jump
 p             Jump to the tag under the cursor, but stay in the Tagbar window.
+                Map option: tagbar_map_preview
 <LeftMouse>   When on a fold icon, open or close the fold depending on the
               current state.
 <2-LeftMouse> Same as <CR>. See |g:tagbar_singleclick| if you want to use a
               single- instead of a double-click.
+<C-N>         Go to the next top-level tag.
+                Map option: tagbar_map_nexttag
+<C-P>         Go to the previous top-level tag.
+                Map option: tagbar_map_prevtag
 <Space>       Display the prototype of the current tag (i.e. the line defining
               it) in the command line.
+                Map option: tagbar_map_showproto
 +/zo          Open the fold under the cursor.
+                Map option: tagbar_map_openfold
 -/zc          Close the fold under the cursor or the current one if there is
               no fold under the cursor.
+                Map option: tagbar_map_closefold
 o/za          Toggle the fold under the cursor or the current one if there is
               no fold under the cursor.
+                Map option: tagbar_map_togglefold
 */zR          Open all folds by setting foldlevel to 99.
+                Map option: tagbar_map_openallfolds
 =/zM          Close all folds by setting foldlevel to 0.
-<C-N>         Go to the next top-level tag.
-<C-P>         Go to the previous top-level tag.
+                Map option: tagbar_map_closeallfolds
 s             Toggle sort order between name and file order.
+                Map option: tagbar_map_togglesort
 x             Toggle zooming the window.
+                Map option: tagbar_map_zoomwin
 q             Close the Tagbar window.
+                Map option: tagbar_map_close
+
+These mappings can be redefined with the given map options. The argument can
+be either a string or a |List| of strings. In the latter case the
+functionality will be assigned to all of the keys in the list. For example, if
+you want to remap the sort toggling functionality to "r":
+>
+        let g:tagbar_map_togglesort = "r"
+<
+See |key-notation| for how to write special keys like <Space> or the keypad
+keys.
 
 ==============================================================================
 5. Configuration                                        *tagbar-configuration*
@@ -443,6 +470,23 @@ Example:
         let g:tagbar_show_visibility = 0
 <
 
+                                                   *g:tagbar_show_linenumbers*
+g:tagbar_show_linenumbers~
+Default: 0
+
+Whether line numbers should be shown in the Tagbar window.
+
+Possible values are:
+  0: Don't show any line numbers.
+  1: Show absolute line numbers.
+  2: Show relative line numbers.
+  -1: Use the global line number settings.
+
+Example:
+>
+        let g:tagbar_show_linenumbers = 2
+<
+
                                                              *g:tagbar_expand*
 g:tagbar_expand~
 Default: 0
@@ -492,7 +536,7 @@ Examples (don't worry if some of the characters aren't displayed correctly,
 just choose other characters in that case):
 >
         let g:tagbar_iconchars = ['▶', '▼']  (default on Linux and Mac OS X)
-        let g:tagbar_iconchars = ['▾', '▸']
+        let g:tagbar_iconchars = ['▸', '▾']
         let g:tagbar_iconchars = ['▷', '◢']
         let g:tagbar_iconchars = ['+', '-']  (default on Windows)
 <
@@ -501,11 +545,14 @@ just choose other characters in that case):
 g:tagbar_autoshowtag~
 Default: 0
 
-If this variable is set and the current tag is inside of a closed fold then
-the folds will be opened as much as needed for the tag to be visible so it can
-be highlighted. If it is not set then the folds won't be opened and the parent
-tag will be highlighted instead. You can use the |:TagbarShowTag| command to
-open the folds manually.
+If this variable is set to 1 and the current tag is inside of a closed fold
+then the folds will be opened as much as needed for the tag to be visible so
+it can be highlighted. If it is set to 0 then the folds will only be opened
+when opening the Tagbar window and the current tag is insided a closed fold,
+otherwise the folds won't be opened and the parent tag will be highlighted
+instead. If it is set to 2 then the folds will never be opened automatically.
+
+You can use the |:TagbarShowTag| command to open the folds manually.
 
 Example:
 >
@@ -533,6 +580,33 @@ your encoding is latin1) |+iconv| features to work.
 Example:
 >
         let g:tagbar_systemenc = 'cp936'
+<
+
+                                                        *g:tagbar_status_func*
+g:tagbar_status_func~
+Default: undefined
+
+This is the name of a function whose return value will be used to draw the
+statusline of the Tagbar window.
+
+The function has to take three arguments:
+  1. current: Whether Tagbar is the current window; 0 or 1.
+  2. sort: The sort order of the tags; 'Name' if they are sorted by name and
+     'Order' if they are sorted by their order of appearance in the file.
+  3. fname: The name of the file that the tags belong to.
+
+In order to avoid possible future additions to the arguments resulting in an
+error it is recommended to add an additional vararg to the signature (see
+|a:0|).
+
+Here is an example that, when put into your vimrc, will emulate Tagbar's
+default statusline:
+>
+        function! TagbarStatusFunc(current, sort, fname, ...) abort
+            let colour = a:current ? '%#StatusLine#' : '%#StatusLineNC#'
+            return colour . '[' . a:sort . '] ' . a:fname
+        endfunction
+        let g:tagbar_status_func = 'TagbarStatusFunc'
 <
 
 ------------------------------------------------------------------------------

--- a/bundle/tagbar/doc/tags
+++ b/bundle/tagbar/doc/tags
@@ -19,9 +19,11 @@ g:tagbar_foldlevel	tagbar.txt	/*g:tagbar_foldlevel*
 g:tagbar_iconchars	tagbar.txt	/*g:tagbar_iconchars*
 g:tagbar_indent	tagbar.txt	/*g:tagbar_indent*
 g:tagbar_left	tagbar.txt	/*g:tagbar_left*
+g:tagbar_show_linenumbers	tagbar.txt	/*g:tagbar_show_linenumbers*
 g:tagbar_show_visibility	tagbar.txt	/*g:tagbar_show_visibility*
 g:tagbar_singleclick	tagbar.txt	/*g:tagbar_singleclick*
 g:tagbar_sort	tagbar.txt	/*g:tagbar_sort*
+g:tagbar_status_func	tagbar.txt	/*g:tagbar_status_func*
 g:tagbar_systemenc	tagbar.txt	/*g:tagbar_systemenc*
 g:tagbar_updateonsave_maxlines	tagbar.txt	/*g:tagbar_updateonsave_maxlines*
 g:tagbar_width	tagbar.txt	/*g:tagbar_width*

--- a/bundle/tagbar/plugin/tagbar.vim
+++ b/bundle/tagbar/plugin/tagbar.vim
@@ -42,49 +42,33 @@ if v:version == 700 && !has('patch167')
     finish
 endif
 
-if !exists('g:tagbar_left')
-    let g:tagbar_left = 0
-endif
+function! s:init_var(var, value) abort
+    if !exists('g:tagbar_' . a:var)
+        execute 'let g:tagbar_' . a:var . ' = ' . string(a:value)
+    endif
+endfunction
 
-if !exists('g:tagbar_width')
-    let g:tagbar_width = 40
-endif
+let s:options = [
+    \ ['autoclose', 0],
+    \ ['autofocus', 0],
+    \ ['autoshowtag', 0],
+    \ ['compact', 0],
+    \ ['expand', 0],
+    \ ['foldlevel', 99],
+    \ ['indent', 2],
+    \ ['left', 0],
+    \ ['show_visibility', 1],
+    \ ['show_linenumbers', 0],
+    \ ['singleclick', 0],
+    \ ['sort', 1],
+    \ ['systemenc', &encoding],
+    \ ['width', 40],
+\ ]
 
-if !exists('g:tagbar_autoclose')
-    let g:tagbar_autoclose = 0
-endif
-
-if !exists('g:tagbar_autofocus')
-    let g:tagbar_autofocus = 0
-endif
-
-if !exists('g:tagbar_sort')
-    let g:tagbar_sort = 1
-endif
-
-if !exists('g:tagbar_compact')
-    let g:tagbar_compact = 0
-endif
-
-if !exists('g:tagbar_indent')
-    let g:tagbar_indent = 2
-endif
-
-if !exists('g:tagbar_show_visibility')
-    let g:tagbar_show_visibility = 1
-endif
-
-if !exists('g:tagbar_expand')
-    let g:tagbar_expand = 0
-endif
-
-if !exists('g:tagbar_singleclick')
-    let g:tagbar_singleclick = 0
-endif
-
-if !exists('g:tagbar_foldlevel')
-    let g:tagbar_foldlevel = 99
-endif
+for [opt, val] in s:options
+    call s:init_var(opt, val)
+endfor
+unlet s:options
 
 if !exists('g:tagbar_iconchars')
     if has('multi_byte') && has('unix') && &encoding == 'utf-8' &&
@@ -95,13 +79,30 @@ if !exists('g:tagbar_iconchars')
     endif
 endif
 
-if !exists('g:tagbar_autoshowtag')
-    let g:tagbar_autoshowtag = 0
-endif
+let s:keymaps = [
+    \ ['jump',      '<CR>'],
+    \ ['preview',   'p'],
+    \ ['nexttag',   '<C-N>'],
+    \ ['prevtag',   '<C-P>'],
+    \ ['showproto', '<Space>'],
+    \
+    \ ['openfold',      ['+', '<kPlus>', 'zo']],
+    \ ['closefold',     ['-', '<kMinus>', 'zc']],
+    \ ['togglefold',    ['o', 'za']],
+    \ ['openallfolds',  ['*', '<kMultiply>', 'zR']],
+    \ ['closeallfolds', ['=', 'zM']],
+    \
+    \ ['togglesort', 's'],
+    \ ['zoomwin',    'x'],
+    \ ['close',      'q'],
+    \ ['help',       '<F1>'],
+\ ]
 
-if !exists('g:tagbar_systemenc')
-    let g:tagbar_systemenc = &encoding
-endif
+for [map, key] in s:keymaps
+    call s:init_var('map_' . map, key)
+    unlet key
+endfor
+unlet s:keymaps
 
 augroup TagbarSession
     autocmd!
@@ -109,6 +110,7 @@ augroup TagbarSession
 augroup END
 
 " Commands {{{1
+command! -nargs=0 Tagbar              call tagbar#ToggleWindow()
 command! -nargs=0 TagbarToggle        call tagbar#ToggleWindow()
 command! -nargs=? TagbarOpen          call tagbar#OpenWindow(<f-args>)
 command! -nargs=0 TagbarOpenAutoClose call tagbar#OpenWindow('fcj')

--- a/bundle/tagbar/syntax/tagbar.vim
+++ b/bundle/tagbar/syntax/tagbar.vim
@@ -30,13 +30,18 @@ execute "syntax match TagbarVisibilityPrivate '" . s:pattern . "'"
 
 unlet s:pattern
 
+syntax match TagbarHelp      '^".*' contains=TagbarHelpKey,TagbarHelpTitle
+syntax match TagbarHelpKey   '" \zs.*\ze:' contained
+syntax match TagbarHelpTitle '" \zs-\+ \w\+ -\+' contained
+
 syntax match TagbarNestedKind '^\s\+\[[^]]\+\]$'
-syntax match TagbarComment    '^".*'
 syntax match TagbarType       ' : \zs.*'
 syntax match TagbarSignature  '(.*)'
 syntax match TagbarPseudoID   '\*\ze :'
 
-highlight default link TagbarComment    Comment
+highlight default link TagbarHelp       Comment
+highlight default link TagbarHelpKey    Identifier
+highlight default link TagbarHelpTitle  PreProc
 highlight default link TagbarKind       Identifier
 highlight default link TagbarNestedKind TagbarKind
 highlight default link TagbarScope      Title

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -1567,7 +1567,7 @@ Local customizations:
   CTRL-Q CTRL-T - toggle the tagbar (:TagbarToggle)
   CTRL-Q T      - toggle the tagbar (:TagbarToggle)
 
-Version 2013-06-03 (2ebd2a13) from https://github.com/majutsushi/tagbar
+Version 2013-08-24 (24efd12f) from https://github.com/majutsushi/tagbar
 
 Installation:
 - Follow bundle installation instructions (|bundle_installation|).

--- a/vimrc
+++ b/vimrc
@@ -2223,13 +2223,6 @@ augroup END
 " Tagbar
 " -------------------------------------------------------------
 
-" Wrapper to update Powerline's status line if Powerline is enabled.
-function! UpdatePowerlineStatus()
-    if g:EnablePowerline
-        call Pl#UpdateStatusline(1)
-    endif
-endfunction
-
 " Must have ctags of some kind or keep plugin from running.
 let usingTagbar = executable("ctags") || executable("ctags.exe")
 if !usingTagbar
@@ -2243,9 +2236,9 @@ let g:tagbar_width = 40
 let g:tagbar_autoclose = 1
 let g:tagbar_autofocus = 1
 
-nnoremap <silent> <S-F8>     :TagbarToggle<CR>:call UpdatePowerlineStatus()<CR>
-nnoremap <silent> <C-Q><C-T> :TagbarToggle<CR>:call UpdatePowerlineStatus()<CR>
-nnoremap <silent> <C-Q>t     :TagbarToggle<CR>:call UpdatePowerlineStatus()<CR>
+nnoremap <silent> <S-F8>     :TagbarToggle<CR>
+nnoremap <silent> <C-Q><C-T> :TagbarToggle<CR>
+nnoremap <silent> <C-Q>t     :TagbarToggle<CR>
 
 " Support for reStructuredText, if available.
 if executable("rst2ctags")


### PR DESCRIPTION
This has the fix for autocmds being disabled.  We can now remove our
hack to make sure that Powerline is updated correctly.
