### PR TITLE
Update to v0.1.1 of rst2ctags.

### DIFF
--- a/tool/rst2ctags/rst2ctags.py
+++ b/tool/rst2ctags/rst2ctags.py
@@ -10,7 +10,7 @@ import sys
 import re
 
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 class ScriptError(Exception):
@@ -164,9 +164,8 @@ def genTagsFile(output, tags, sort):
     else:
         sortedLine = '!_TAG_FILE_SORTED\t0\n'
 
-    if output != sys.stdout:
-        output.write('!_TAG_FILE_FORMAT\t2\n')
-        output.write(sortedLine)
+    output.write('!_TAG_FILE_FORMAT\t2\n')
+    output.write(sortedLine)
 
     for t in tags:
         output.write(str(t))


### PR DESCRIPTION
TagBar treats empty output from a ctags-like executable as though it
were unsuccessful.  This version will now emit the headers to stdout.
