### PR TITLE
Update to a newer version of TagBar.

### DIFF
--- a/bundle/tagbar/autoload/tagbar.vim
+++ b/bundle/tagbar/autoload/tagbar.vim
@@ -964,9 +964,9 @@ function! s:CreateAutocommands() abort
         autocmd WinEnter   __Tagbar__ call s:SetStatusLine('current')
         autocmd WinLeave   __Tagbar__ call s:SetStatusLine('noncurrent')
 
-        autocmd BufReadPost,BufWritePost * call
+        autocmd BufWritePost * call
                     \ s:AutoUpdate(fnamemodify(expand('<afile>'), ':p'), 1)
-        autocmd BufEnter,CursorHold,FileType * call
+        autocmd BufReadPost,BufEnter,CursorHold,FileType * call
                     \ s:AutoUpdate(fnamemodify(expand('<afile>'), ':p'), 0)
         autocmd BufDelete,BufUnload,BufWipeout * call
                     \ s:known_files.rm(fnamemodify(expand('<afile>'), ':p'))
@@ -1711,7 +1711,8 @@ function! s:OpenWindow(flags) abort
 
     " Expand the Vim window to accomodate for the Tagbar window if requested
     " and save the window positions to be able to restore them later.
-    if g:tagbar_expand && !s:window_expanded && has('gui_running')
+    if g:tagbar_expand >= 1 && !s:window_expanded &&
+     \ (has('gui_running') || g:tagbar_expand == 2)
         let s:window_pos.pre.x = getwinposx()
         let s:window_pos.pre.y = getwinposy()
         let &columns += g:tagbar_width + 1
@@ -1869,13 +1870,14 @@ function! s:CloseWindow() abort
         if index(tablist, tagbarbufnr) == -1
             let &columns -= g:tagbar_width + 1
             let s:window_expanded = 0
-            " Only restore window position if it hasn't been moved manually
-            " after the expanding
-            if getwinposx() == s:window_pos.post.x &&
+            " Only restore window position if it is available and if the
+            " window hasn't been moved manually after the expanding
+            if getwinposx() != -1 &&
+             \ getwinposx() == s:window_pos.post.x &&
              \ getwinposy() == s:window_pos.post.y
                execute 'winpos ' . s:window_pos.pre.x .
                            \ ' ' . s:window_pos.pre.y
-           endif
+            endif
         endif
     endif
 

--- a/bundle/tagbar/doc/tagbar.txt
+++ b/bundle/tagbar/doc/tagbar.txt
@@ -491,8 +491,10 @@ Example:
 g:tagbar_expand~
 Default: 0
 
-If this option is set the Vim window will be expanded by the width of the
-Tagbar window if using a GUI version of Vim.
+If this option is set to 1 the Vim window will be expanded by the width of the
+Tagbar window if using a GUI version of Vim. Setting it to 2 will also try
+expanding a terminal, but note that this is not supported by all terminals.
+See also |xterm-resize|.
 
 Example:
 >

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -1688,7 +1688,7 @@ Local customizations:
   CTRL-Q CTRL-T - toggle the tagbar (:TagbarToggle)
   CTRL-Q T      - toggle the tagbar (:TagbarToggle)
 
-Version 2013-08-24 (24efd12f) from https://github.com/majutsushi/tagbar
+Version 2013-09-18 (5566cb34) from https://github.com/majutsushi/tagbar
 
 Installation:
 - Follow bundle installation instructions (|bundle_installation|).


### PR DESCRIPTION
This one includes the fix to avoid forcefully re-running ctags
generation on BufReadPost.
