### PR TITLE
Initialize b:UltiSnipsSnippetDirectories if it doesn't exist.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -2411,6 +2411,10 @@ endfunction
 
 " Helper to be called from your .lvimrc.
 function! AppendSnippetDirs(snippetDirs)
+    if !exists("b:UltiSnipsSnippetDirectories")
+        let b:UltiSnipsSnippetDirectories = copy(g:UltiSnipsSnippetDirectories)
+    endif
+
     if type(a:snippetDirs) == type([])
         let b:UltiSnipsSnippetDirectories += a:snippetDirs
     else


### PR DESCRIPTION
Now that UltiSnips pays attention to b:UltiSnipsSnippetDirectories and
our workaround is removed, there's the possibility that
b:UltiSnipsSnippetDirectories doesn't exist.  Let's borrow from our old
behavior by copying the global setting to our buffer-local variable,
and append to the copy.
