### PR TITLE
Support markdown sections in TagBar.

### DIFF
--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -1886,6 +1886,10 @@ Added support for reStructuredText using rst2ctags.  rst2ctags can be found
 at https://github.com/jszakmeister/rst2ctags, and a copy has been embedded
 in $VIMFILES/tool/rst2ctags.
 
+Also added support for markdown using markdown2ctags.  markdown2ctags can be
+found at https://github.com/jszakmeister/markdown2ctags, and a copy has been
+embedded in $VIMFILES/tool/markdown2ctags.
+
 ------------------------------------------------------------------------------
 TAGSIGNATURE                                            *notes_tagsignature*
   Balloon signatures for tags

--- a/tool/markdown2ctags/LICENSE.txt
+++ b/tool/markdown2ctags/LICENSE.txt
@@ -1,0 +1,26 @@
+Copyright (C) 2013, John Szakmeister <john@szakmeister.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the distribution.
+3. Neither the name of the author nor the names of its contributors may be 
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tool/markdown2ctags/README.md
+++ b/tool/markdown2ctags/README.md
@@ -1,0 +1,37 @@
+# markdown2ctags
+
+This application generates ctags-compatible output for the sections of a
+Markdown document.
+
+The motivation was to have a tool fast enough to use with the
+[TagBar](https://github.com/majutsushi/tagbar) plugin in Vim.
+
+## Using with TagBar
+
+To use this tool with TagBar, add the following into your `~/.vimrc`:
+
+    " Add support for markdown files in tagbar.
+    let g:tagbar_type_markdown = {
+        \ 'ctagstype': 'markdown',
+        \ 'ctagsbin' : '/path/to/markdown2ctags.py',
+        \ 'ctagsargs' : '-f - --sort=yes',
+        \ 'kinds' : [
+            \ 's:sections',
+            \ 'i:images'
+        \ ],
+        \ 'sro' : '|',
+        \ 'kind2scope' : {
+            \ 's' : 'section',
+        \ },
+        \ 'sort': 0,
+    \ }
+
+You'll need to have the TagBar plugin installed for this to work.  Also, you
+make need to call the variable `g:tagbar_type_mkd` and change `ctagstype` to
+`'mkd'` if you're Ben William's Markdown syntax highlighting script.  It sets
+the file type to `mkd` whereas Tim Pope's sets it to `markdown`.
+
+## License
+
+This tool is licensed under a Simplified BSD license.  See ``LICENSE.txt`` for
+details.

--- a/tool/markdown2ctags/markdown2ctags.py
+++ b/tool/markdown2ctags/markdown2ctags.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2013 John Szakmeister <john@szakmeister.net>
+# All rights reserved.
+#
+# This software is licensed as described in the file LICENSE.txt, which
+# you should have received as part of this distribution.
+
+import sys
+import re
+
+
+__version__ = '0.1.0'
+
+
+class ScriptError(Exception):
+    pass
+
+
+class Tag(object):
+    def __init__(self, tagName, tagFile, tagAddress):
+        self.tagName = tagName
+        self.tagFile = tagFile
+        self.tagAddress = tagAddress
+        self.fields = []
+
+    def addField(self, type, value=None):
+        if type == 'kind':
+            type = None
+        self.fields.append((type, value or ""))
+
+    def _formatFields(self):
+        formattedFields = []
+        for name, value in self.fields:
+            if name:
+                s = '%s:%s' % (name, value or "")
+            else:
+                s = str(value)
+            formattedFields.append(s)
+        return '\t'.join(formattedFields)
+
+    def __str__(self):
+        return '%s\t%s\t%s;"\t%s' % (
+                self.tagName, self.tagFile, self.tagAddress,
+                self._formatFields())
+
+    def __cmp__(self, other):
+        return cmp(str(self), str(other))
+
+    @staticmethod
+    def section(section):
+        tagAddress = '/^%s$/' % section.line
+        t = Tag(section.name, section.filename, tagAddress)
+        t.addField('kind', 's')
+        t.addField('line', section.lineNumber)
+
+        parents = []
+        p = section.parent
+        while p is not None:
+            parents.append(p.name)
+            p = p.parent
+        parents.reverse()
+
+        if parents:
+            t.addField('section', '|'.join(parents))
+
+        return t
+
+
+class Section(object):
+    def __init__(self, level, name, line, lineNumber, filename, parent=None):
+        self.level = level
+        self.name = name
+        self.line = line
+        self.lineNumber = lineNumber
+        self.filename = filename
+        self.parent = parent
+
+    def __repr__(self):
+        return '<Section %s %d %d>' % (self.name, self.level, self.lineNumber)
+
+
+atxHeadingRe = re.compile(r'^(#+)\s+(.*?)(?:\s+#+)?\s*$')
+settextHeadingRe = re.compile(r'^[-=]+$')
+settextSubjectRe = re.compile(r'^[^\s]+.*$')
+
+def findSections(filename, lines):
+    sections = []
+    previousSections = []
+
+    for i, line in enumerate(lines):
+        m = atxHeadingRe.match(line)
+        if m:
+            level = len(m.group(1))
+            name = m.group(2)
+
+            previousSections = previousSections[:level-1]
+            if previousSections:
+                parent = previousSections[-1]
+            else:
+                parent = None
+            lineNumber = i + 1
+
+            s = Section(level, name, line, lineNumber, filename, parent)
+            previousSections.append(s)
+            sections.append(s)
+        else:
+            m = settextHeadingRe.match(line)
+            if i and m:
+                if not settextSubjectRe.match(lines[i - 1]):
+                    continue
+
+                name = lines[i-1].strip()
+
+                if line[0] == '=':
+                    level = 1
+                else:
+                    level = 2
+
+                previousSections = previousSections[:level-1]
+                if previousSections:
+                    parent = previousSections[-1]
+                else:
+                    parent = None
+                lineNumber = i
+
+                s = Section(level, name, lines[i-1], lineNumber,
+                        filename, parent)
+                previousSections.append(s)
+                sections.append(s)
+
+    return sections
+
+
+def sectionsToTags(sections):
+    tags = []
+
+    for section in sections:
+        tags.append(Tag.section(section))
+
+    return tags
+
+
+def genTagsFile(output, tags, sort):
+    if sort == "yes":
+        tags = sorted(tags)
+        sortedLine = '!_TAG_FILE_SORTED\t1\n'
+    elif sort == "foldcase":
+        tags = sorted(tags, key=lambda x: str(x).lower())
+        sortedLine = '!_TAG_FILE_SORTED\t2\n'
+    else:
+        sortedLine = '!_TAG_FILE_SORTED\t0\n'
+
+    output.write('!_TAG_FILE_FORMAT\t2\n')
+    output.write(sortedLine)
+
+    for t in tags:
+        output.write(str(t))
+        output.write('\n')
+
+
+def main():
+    from optparse import OptionParser
+
+    parser = OptionParser(usage = "usage: %prog [options] file(s)",
+                          version = __version__)
+    parser.add_option(
+            "-f", "--file", metavar = "FILE", dest = "tagfile",
+            default = "tags",
+            help = 'Write tags into FILE (default: "tags").  Use "-" to write '
+                   'tags to stdout.')
+    parser.add_option(
+            "", "--sort", metavar="[yes|foldcase|no]", dest = "sort",
+            choices = ["yes", "no", "foldcase"],
+            default = "yes",
+            help = 'Produce sorted output.  Acceptable values are "yes", '
+                   '"no", and "foldcase".  Default is "yes".')
+
+    options, args = parser.parse_args()
+
+    if options.tagfile == '-':
+        output = sys.stdout
+    else:
+        output = open(options.tagfile, 'wb')
+
+    for filename in args:
+        f = open(filename, 'rb')
+        lines = f.read().splitlines()
+        f.close()
+        sections = findSections(filename, lines)
+
+        genTagsFile(output, sectionsToTags(sections), sort=options.sort)
+
+    output.flush()
+    output.close()
+
+if __name__ == '__main__':
+    try:
+        main()
+    except IOError as e:
+        import errno
+        if e.errno == errno.EPIPE:
+            # Exit saying we got SIGPIPE.
+            sys.exit(141)
+        raise
+    except ScriptError as e:
+        print >>sys.stderr, "ERROR: %s" % str(e)
+        sys.exit(1)

--- a/vimrc
+++ b/vimrc
@@ -2653,6 +2653,35 @@ let g:local_tagbar_type_rst = {
 "   unlet g:tagbar_type_rst.
 let g:tagbar_type_rst = g:local_tagbar_type_rst
 
+" Support for markdown, if available.
+if executable("markdown2ctags")
+    let g:markdown2ctags = 'markdown2ctags'
+else
+    let g:markdown2ctags = $VIMFILES . '/tool/markdown2ctags/markdown2ctags.py'
+endif
+
+" Local tagbar settings.  Assign g:tagbar_type_markdown to this value to enable
+" support for markdown files in tagbar.
+let g:local_tagbar_type_markdown = {
+    \ 'ctagstype': 'markdown',
+    \ 'ctagsbin' : g:markdown2ctags,
+    \ 'ctagsargs' : '-f - --sort=yes',
+    \ 'kinds' : [
+        \ 's:sections',
+        \ 'i:images'
+    \ ],
+    \ 'sro' : '|',
+    \ 'kind2scope' : {
+        \ 's' : 'section',
+    \ },
+    \ 'sort': 0,
+\ }
+
+" Enable support for markdown files in tagbar by default.  Disable if desired in
+" your |VIMRC_AFTER| file via:
+"   unlet g:tagbar_type_markdown.
+let g:tagbar_type_markdown = g:local_tagbar_type_markdown
+
 " -------------------------------------------------------------
 " textobj-diff
 " -------------------------------------------------------------


### PR DESCRIPTION
This adds support for Markdown files in the same way that we support reStructuredText.  I created a `markdown2ctags` tool and embedded into vimfiles, just like `rst2ctags`.
