### PR TITLE
Define UltiSnips_FileTypeChanged() when UltiSnips is disabled.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -2936,6 +2936,10 @@ if g:EnableUltiSnips
 else
     " UltiSnips will not load if this variable is defined:
     let g:did_UltiSnips_vim = 1
+
+    function! UltiSnips_FileTypeChanged()
+        " Do nothing.
+    endfunction
 endif
 
 " -------------------------------------------------------------


### PR DESCRIPTION
This will prevent some errors when running with UltiSnips disabled.
