### PR TITLE
Move the definition of UltiSnips#FileTypeChanged to prevent an error.

### DIFF
--- a/after/plugin/UltiSnips.vim
+++ b/after/plugin/UltiSnips.vim
@@ -1,0 +1,5 @@
+if !g:EnableUltiSnips
+    function! UltiSnips#FileTypeChanged()
+        " Do nothing.
+    endfunction
+endif

--- a/vimrc
+++ b/vimrc
@@ -2939,9 +2939,9 @@ else
     let g:did_UltiSnips_autoload = 1
     let g:did_UltiSnips_plugin = 1
 
-    function! UltiSnips#FileTypeChanged()
-        " Do nothing.
-    endfunction
+    " The definition of UltiSnips#FileTypeChanged is in
+    " after/plugin/UltiSnips.vim to prevent an error about the function name not
+    " matching the script file name.
 endif
 
 " -------------------------------------------------------------


### PR DESCRIPTION
Recently, Neovim started reporting an error since this function was
being defined in our vimrc but has a prefix of `UltiSnips#`.  This
moves the definition to after the plugin loads, and checks
g:EnableUltiSnips to define the dummy function.
