### PR TITLE
Set better javadoc title and tag colors in szakdark.

### DIFF
--- a/colors/szakdark.vim
+++ b/colors/szakdark.vim
@@ -237,3 +237,7 @@ hi IndentGuidesEven guibg=#212121 ctermbg=235
 
 " Git
 hi gitcommitSummary guifg=#96CBFE gui=BOLD ctermfg=lightblue cterm=BOLD
+
+" Java
+hi javaCommentTitle guifg=#7C7C7C gui=BOLD
+hi link javaDocTags javaCommentTitle


### PR DESCRIPTION
The default color is white, which distracts you from the code.
