### PR TITLE
Add the ability to "inherit" from a directory.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -42,6 +42,34 @@ function! RtpPrepend(path)
     endif
 endfunction
 
+" Inserts a directory right after $VIMUSERFILES in the runtimepath.  If an after
+" directory exists, it inserts the /after folder to just before the one in
+" VIMUSERFILES, or tacks it at the end of the runtimepath if $VIMUSEFILES/after
+" is not in the runtimepath.
+"
+" The goal here is to allow inheriting another user's configuration.  This will
+" get the runtimepath fixed up correctly, but you still need to source the
+" before and after scripts within your before and after scripts, respectively.
+function! InheritDirectory(path)
+    if isdirectory(a:path)
+        let l = split(&runtimepath, ",")
+        let i = index(l, $VIMUSERFILES) + 1
+        call insert(l, a:path, i)
+
+        if isdirectory(a:path . '/after')
+            let i = index(l, $VIMUSERFILES . "/after")
+
+            if i < 0
+                call add(l, a:path . '/after')
+            else
+                call insert(l, a:path . "/after", i)
+            endif
+        endif
+
+        let &runtimepath = join(l, ",")
+    endif
+endfunction
+
 " -------------------------------------------------------------
 " Pathogen plugin management (part one)
 " -------------------------------------------------------------


### PR DESCRIPTION
This it to help with folks who want to derive their configuration from
another person's.  It will insert the inherited directory just after
your own in the runtimepath, and insert the after/ directory in the
correct location, if it exists.  Then you can add the following to your
vimrc-before.vim:

```
call InheritDirectory(expand("$VIMFILES/user/name"))
exec "source " . expand("$VIMFILES/user/name/vimrc-before.vim")
```

and the following to your vimrc-after.vim:

```
exec "source " . expand("$VIMFILES/user/name/vimrc-after.vim")
```

where "name" is the name of the user's setting you want to inherit.
