### PR TITLE
Add a blank line at the start of the footer in startify.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -2800,6 +2800,7 @@ let g:startify_custom_header = [
   \ ]
 
 let g:startify_custom_footer = [
+  \ "",
   \ "[e] - open an empty buffer, closing startify",
   \ "[q] - close startify window (quit Vim if only window)",
   \ "[i] - enter insert mode in an empty buffer, closing startify",


### PR DESCRIPTION
It helps to visually break up the sections a little better.
