### PR TITLE
Add a SetupShell.

### DIFF
--- a/after/ftplugin/sh.vim
+++ b/after/ftplugin/sh.vim
@@ -1,1 +1,1 @@
-SetupSource
+SetupShell

--- a/after/ftplugin/zsh.vim
+++ b/after/ftplugin/zsh.vim
@@ -1,1 +1,1 @@
-SetupSource
+SetupShell

--- a/vimrc
+++ b/vimrc
@@ -4237,6 +4237,18 @@ endfunction
 command! -bar SetupRuby call SetupRuby()
 
 " -------------------------------------------------------------
+" Setup for shell languages like sh and zsh.
+" -------------------------------------------------------------
+
+function! SetupShell()
+    SetupSource
+
+    " Re-synchronize syntax highlighting from start of file.
+    syntax sync fromstart
+endfunction
+command! -bar SetupShell call SetupShell()
+
+" -------------------------------------------------------------
 " Setup for Subversion commit files.
 " -------------------------------------------------------------
 function! SetupSvn()


### PR DESCRIPTION
It turns out that syntax highlighting for shell languages can get lost
quite often, so some extra setup is necessary for them.
