### PR TITLE
Add an AddTags() function for use within .lvimrc files.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -726,6 +726,19 @@ function! NumCpus()
     return n
 endfunction
 
+" Helper for adding tag files from your $HOME/.tags folder.  Useful within
+" .lvimrc files.
+function! AddTags(...)
+    let index = 1
+    while index <= a:0
+        let tagPath = expand("$HOME/.tags/") . a:{index} . ".tags"
+        if filereadable(tagPath) == 1
+            execute 'setlocal tags+=' . escape(tagPath, ' \')
+        endif
+        let index = index + 1
+    endwhile
+endfunction
+
 " -------------------------------------------------------------
 " QuickFix/Location List support
 " -------------------------------------------------------------


### PR DESCRIPTION
I find myself tagging the /usr/include area (or at least portions of
it) and the kernel tree for use in other projects.  This lets me keep
the tags in a useful location, and add them in as I need them for
projects.
