### PR TITLE
Provide better default font sizes based on platform.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -29,6 +29,41 @@ set fileencodings=ucs-bom,utf-8,default,latin1
 " directory $HOME/.vim on Unix or %USERPROFILE%\vimfiles on Windows.
 let $VIMFILES = expand("<sfile>:p:h")
 
+function! DetectPlatform()
+    if has("gui_win32")
+        return "win32"
+    endif
+
+    " Assume we're on a Unix box.
+    let name = substitute(system("uname"), '^\_s*\(.\{-}\)\_s*$', '\1', '')
+
+    return tolower(name)
+endfunction
+
+function! DetectVmware(platform)
+    if a:platform == "linux"
+        if filereadable("/sys/class/dmi/id/sys_vendor")
+            for line in readfile("/sys/class/dmi/id/sys_vendor", '', 10)
+                if line =~ '\cvmware'
+                    return 1
+                endif
+            endfor
+        endif
+    elseif a:platform == "freebsd"
+        if executable("kldstat")
+            let output = system("kldstat")
+            if output =~ "vmxnet"
+                return 1
+            endif
+        endif
+    endif
+
+    return 0
+endfunction
+
+let g:Platform = DetectPlatform()
+let g:InVmware = DetectVmware(g:Platform)
+
 " -------------------------------------------------------------
 " List manipulation
 " -------------------------------------------------------------

--- a/vimrc
+++ b/vimrc
@@ -64,6 +64,18 @@ endfunction
 let g:Platform = DetectPlatform()
 let g:InVmware = DetectVmware(g:Platform)
 
+function! AdjustBaseFontSize(size)
+    if g:Platform != "darwin"
+        return a:size
+    endif
+
+    " Mac's idea of a point on screen is not the same as everyone else's.
+    " It appears that most operating systems either expect the screen to be 96
+    " DPI, or will query the monitor.  Mac, on the other hand, assumes that the
+    " monitor is 72 DPI.
+    return ((a:size * 96) + 35) / 72
+endfunction
+
 " -------------------------------------------------------------
 " List manipulation
 " -------------------------------------------------------------
@@ -430,7 +442,7 @@ function! SetFont()
         let g:FontFamily = fontdetect#firstFontFamily(g:DefaultFontFamilies)
     endif
     if !exists("g:FontSize")
-        let g:FontSize = 14
+        let g:FontSize = AdjustBaseFontSize(14)
     endif
     if g:FontFamily != "" && g:FontSize > 0
         if has("gui_gtk2")


### PR DESCRIPTION
I haven't tried detecting whether we are in VirtualBox--I simply don't use it much.  But I'll keep it in mind if I happen to be messing with things at work and find myself using it.