### PR TITLE
Limit diff highlighting within emails to a region.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -3883,25 +3883,37 @@ function! SetupMail()
 
     " Highlight diffs.  Most of this was taken from notmuch's vim integration,
     " but with spelling turned off in the highlighted lines.
-    syn match diffRemoved "^-.*" contains=@NoSpell
-    syn match diffAdded "^+.*" contains=@NoSpell
-
     syn match diffSeparator "^---$"
+
+    syn match diffFile "^diff .*" contains=@NoSpell contained
+    syn match diffIndex "^index .*" contains=@NoSpell contained
+    syn match diffNormal "^ .*" contains=@NoSpell contained
+    syn match diffNormal "^==*" contains=@NoSpell contained
+    syn match diffRemoved "^-.*" contains=@NoSpell contained
+    syn match diffAdded "^+.*" contains=@NoSpell contained
+
+    syn match diffNewFile "^+++ .*" contains=@NoSpell contained
+    syn match diffOldFile "^--- .*" contains=@NoSpell contained
+    syn match diffEndMarker "^-- $" contains=@NoSpell contained
+
     syn match diffSubname " @@..*"ms=s+3 contained
     syn match diffLine "^@.*" contains=diffSubname,@NoSpell
 
-    syn match diffFile "^diff .*" contains=@NoSpell
-    syn match diffNewFile "^+++ .*" contains=@NoSpell
-    syn match diffOldFile "^--- .*" contains=@NoSpell
+    syn region diffHeader matchgroup=diffHeader
+                \ start="^\(\(diff .*\nindex .*\n\|Index: .*\(\n==*\n\)\?\)\?\(^--- .*\n+++ .*$\)\)\@="
+                \ end="\n\n\|-- $" keepend
+                \ contains=diffFile,diffIndex,diffNormal,diffRemoved,diffAdded,diffNewFile,diffOldFile,diffEndMarker,diffLine
 
+    hi def link diffHeader diffFile
+    hi def link diffIndex diffFile
     hi def link diffOldFile diffFile
     hi def link diffNewFile diffFile
-
-    hi def link diffFile Type
     hi def link diffRemoved Special
     hi def link diffAdded Identifier
     hi def link diffLine Statement
     hi def link diffSubname PreProc
+    hi def link diffSeparator diffComment
+    hi def link diffEndMarker diffComment
 
     syntax match gitDiffStatLine /^ .\{-}\zs[+-]\+$/ contains=gitDiffStatAdd,gitDiffStatDelete
     syntax match gitDiffStatAdd /+/ contained


### PR DESCRIPTION
This implements a guard to help detect the beginning and end of a diff
region in emails.  We trigger on some common text leading up to the
diff, and then end the diff when we see an empty line or git's end of
diff marker.

Since I shoved everything into a region, it did require setting up
highlighting for the context lines within the diff to keep from
inheriting diffHeader's coloring.
