### PR TITLE
Update to v0.1.3 of rst2ctags.

### DIFF
--- a/tool/rst2ctags/rst2ctags.py
+++ b/tool/rst2ctags/rst2ctags.py
@@ -10,7 +10,7 @@ import sys
 import re
 
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
 
 class ScriptError(Exception):
@@ -95,7 +95,7 @@ class Section(object):
         return '<Section %s %d %d>' % (self.name, self.level, self.lineNumber)
 
 
-headingRe = re.compile(r'^[-=^"#*.]+$')
+headingRe = re.compile(r'''^[-=~:^"#*._+`']+$''')
 subjectRe = re.compile(r'^[^\s]+.*$')
 
 def findSections(filename, lines):


### PR DESCRIPTION
This updates heading detection to include all of the recommended
characters that can be used to underline headings.
