### PR TITLE
Update syntastic.

### DIFF
--- a/bundle/syntastic/autoload/syntastic/c.vim
+++ b/bundle/syntastic/autoload/syntastic/c.vim
@@ -18,9 +18,17 @@ endfunction " }}}2
 " read additional compiler flags from the given configuration file
 " the file format and its parsing mechanism is inspired by clang_complete
 function! syntastic#c#ReadConfig(file) " {{{2
-    " search in the current file's directory upwards
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_CHECKERS, 'ReadConfig: looking for', a:file)
+
+    " search upwards from the current file's directory
     let config = findfile(a:file, '.;')
-    if config == '' || !filereadable(config)
+    if config == ''
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_CHECKERS, 'ReadConfig: file not found')
+        return ''
+    endif
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_CHECKERS, 'ReadConfig: config file:', config)
+    if !filereadable(config)
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_CHECKERS, 'ReadConfig: file unreadable')
         return ''
     endif
 
@@ -31,6 +39,7 @@ function! syntastic#c#ReadConfig(file) " {{{2
     try
         let lines = readfile(config)
     catch /\m^Vim\%((\a\+)\)\=:E48[45]/
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_CHECKERS, 'ReadConfig: error reading file')
         return ''
     endtry
 
@@ -62,7 +71,7 @@ endfunction " }}}2
 " GetLocList() for C-like compilers
 function! syntastic#c#GetLocList(filetype, subchecker, options) " {{{2
     try
-        let flags = s:getCflags(a:filetype, a:subchecker, a:options)
+        let flags = s:_get_cflags(a:filetype, a:subchecker, a:options)
     catch /\m\C^Syntastic: skip checks$/
         return []
     endtry
@@ -70,9 +79,9 @@ function! syntastic#c#GetLocList(filetype, subchecker, options) " {{{2
     let makeprg = syntastic#util#shexpand(g:syntastic_{a:filetype}_compiler) .
         \ ' ' . flags . ' ' . syntastic#util#shexpand('%')
 
-    let errorformat = s:getCheckerVar('g', a:filetype, a:subchecker, 'errorformat', a:options['errorformat'])
+    let errorformat = s:_get_checker_var('g', a:filetype, a:subchecker, 'errorformat', a:options['errorformat'])
 
-    let postprocess = s:getCheckerVar('g', a:filetype, a:subchecker, 'remove_include_errors', 0) ?
+    let postprocess = s:_get_checker_var('g', a:filetype, a:subchecker, 'remove_include_errors', 0) ?
         \ ['filterForeignErrors'] : []
 
     " process makeprg
@@ -87,29 +96,29 @@ endfunction " }}}2
 " Private functions {{{1
 
 " initialize c/cpp syntax checker handlers
-function! s:init() " {{{2
+function! s:_init() " {{{2
     let s:handlers = []
     let s:cflags = {}
 
-    call s:regHandler('\m\<cairo',       'syntastic#c#checkPKG', ['cairo', 'cairo'])
-    call s:regHandler('\m\<freetype',    'syntastic#c#checkPKG', ['freetype', 'freetype2', 'freetype'])
-    call s:regHandler('\m\<glade',       'syntastic#c#checkPKG', ['glade', 'libglade-2.0', 'libglade'])
-    call s:regHandler('\m\<glib',        'syntastic#c#checkPKG', ['glib', 'glib-2.0', 'glib'])
-    call s:regHandler('\m\<gtk',         'syntastic#c#checkPKG', ['gtk', 'gtk+-2.0', 'gtk+', 'glib-2.0', 'glib'])
-    call s:regHandler('\m\<libsoup',     'syntastic#c#checkPKG', ['libsoup', 'libsoup-2.4', 'libsoup-2.2'])
-    call s:regHandler('\m\<libxml',      'syntastic#c#checkPKG', ['libxml', 'libxml-2.0', 'libxml'])
-    call s:regHandler('\m\<pango',       'syntastic#c#checkPKG', ['pango', 'pango'])
-    call s:regHandler('\m\<SDL',         'syntastic#c#checkPKG', ['sdl', 'sdl'])
-    call s:regHandler('\m\<opengl',      'syntastic#c#checkPKG', ['opengl', 'gl'])
-    call s:regHandler('\m\<webkit',      'syntastic#c#checkPKG', ['webkit', 'webkit-1.0'])
+    call s:_registerHandler('\m\<cairo',       's:_checkPackage', ['cairo', 'cairo'])
+    call s:_registerHandler('\m\<freetype',    's:_checkPackage', ['freetype', 'freetype2', 'freetype'])
+    call s:_registerHandler('\m\<glade',       's:_checkPackage', ['glade', 'libglade-2.0', 'libglade'])
+    call s:_registerHandler('\m\<glib',        's:_checkPackage', ['glib', 'glib-2.0', 'glib'])
+    call s:_registerHandler('\m\<gtk',         's:_checkPackage', ['gtk', 'gtk+-2.0', 'gtk+', 'glib-2.0', 'glib'])
+    call s:_registerHandler('\m\<libsoup',     's:_checkPackage', ['libsoup', 'libsoup-2.4', 'libsoup-2.2'])
+    call s:_registerHandler('\m\<libxml',      's:_checkPackage', ['libxml', 'libxml-2.0', 'libxml'])
+    call s:_registerHandler('\m\<pango',       's:_checkPackage', ['pango', 'pango'])
+    call s:_registerHandler('\m\<SDL',         's:_checkPackage', ['sdl', 'sdl'])
+    call s:_registerHandler('\m\<opengl',      's:_checkPackage', ['opengl', 'gl'])
+    call s:_registerHandler('\m\<webkit',      's:_checkPackage', ['webkit', 'webkit-1.0'])
 
-    call s:regHandler('\m\<php\.h\>',    'syntastic#c#checkPHP',    [])
-    call s:regHandler('\m\<Python\.h\>', 'syntastic#c#checkPython', [])
-    call s:regHandler('\m\<ruby',        'syntastic#c#checkRuby',   [])
+    call s:_registerHandler('\m\<php\.h\>',    's:_checkPhp',    [])
+    call s:_registerHandler('\m\<Python\.h\>', 's:_checkPython', [])
+    call s:_registerHandler('\m\<ruby',        's:_checkRuby',   [])
 endfunction " }}}2
 
-" return a handler dictionary object
-function! s:regHandler(regex, function, args) " {{{2
+" register a handler dictionary object
+function! s:_registerHandler(regex, function, args) " {{{2
     let handler = {}
     let handler["regex"] = a:regex
     let handler["func"] = function(a:function)
@@ -117,8 +126,75 @@ function! s:regHandler(regex, function, args) " {{{2
     call add(s:handlers, handler)
 endfunction " }}}2
 
+" try to find library with 'pkg-config'
+" search possible libraries from first to last given
+" argument until one is found
+function! s:_checkPackage(name, ...) " {{{2
+    if executable('pkg-config')
+        if !has_key(s:cflags, a:name)
+            for pkg in a:000
+                let pkg_flags = system('pkg-config --cflags ' . pkg)
+                " since we cannot necessarily trust the pkg-config exit code
+                " we have to check for an error output as well
+                if v:shell_error == 0 && pkg_flags !~? 'not found'
+                    let pkg_flags = ' ' . substitute(pkg_flags, "\n", '', '')
+                    let s:cflags[a:name] = pkg_flags
+                    return pkg_flags
+                endif
+            endfor
+        else
+            return s:cflags[a:name]
+        endif
+    endif
+    return ''
+endfunction " }}}2
+
+" try to find PHP includes with 'php-config'
+function! s:_checkPhp() " {{{2
+    if executable('php-config')
+        if !has_key(s:cflags, 'php')
+            let s:cflags['php'] = system('php-config --includes')
+            let s:cflags['php'] = ' ' . substitute(s:cflags['php'], "\n", '', '')
+        endif
+        return s:cflags['php']
+    endif
+    return ''
+endfunction " }}}2
+
+" try to find the python headers with distutils
+function! s:_checkPython() " {{{2
+    if executable('python')
+        if !has_key(s:cflags, 'python')
+            let s:cflags['python'] = system('python -c ''from distutils import ' .
+                \ 'sysconfig; import sys; sys.stdout.write(sysconfig.get_python_inc())''')
+            let s:cflags['python'] = substitute(s:cflags['python'], "\n", '', '')
+            let s:cflags['python'] = ' -I' . s:cflags['python']
+        endif
+        return s:cflags['python']
+    endif
+    return ''
+endfunction " }}}2
+
+" try to find the ruby headers with 'rbconfig'
+function! s:_checkRuby() " {{{2
+    if executable('ruby')
+        if !has_key(s:cflags, 'ruby')
+            let s:cflags['ruby'] = system('ruby -r rbconfig -e ' .
+                \ '''puts RbConfig::CONFIG["rubyhdrdir"] || RbConfig::CONFIG["archdir"]''')
+            let s:cflags['ruby'] = substitute(s:cflags['ruby'], "\n", '', '')
+            let s:cflags['ruby'] = ' -I' . s:cflags['ruby']
+        endif
+        return s:cflags['ruby']
+    endif
+    return ''
+endfunction " }}}2
+
+" }}}1
+
+" Utilities {{{1
+
 " resolve checker-related user variables
-function! s:getCheckerVar(scope, filetype, subchecker, name, default) " {{{2
+function! s:_get_checker_var(scope, filetype, subchecker, name, default) " {{{2
     let prefix = a:scope . ':' . 'syntastic_'
     if exists(prefix . a:filetype . '_' . a:subchecker . '_' . a:name)
         return {a:scope}:syntastic_{a:filetype}_{a:subchecker}_{a:name}
@@ -130,10 +206,10 @@ function! s:getCheckerVar(scope, filetype, subchecker, name, default) " {{{2
 endfunction " }}}2
 
 " resolve user CFLAGS
-function! s:getCflags(ft, ck, opts) " {{{2
+function! s:_get_cflags(ft, ck, opts) " {{{2
     " determine whether to parse header files as well
-    if has_key(a:opts, 'header_names') && expand('%') =~? a:opts['header_names']
-        if s:getCheckerVar('g', a:ft, a:ck, 'check_header', 0)
+    if has_key(a:opts, 'header_names') && expand('%', 1) =~? a:opts['header_names']
+        if s:_get_checker_var('g', a:ft, a:ck, 'check_header', 0)
             let flags = get(a:opts, 'header_flags', '') . ' -c ' . syntastic#c#NullOutput()
         else
             " checking headers when check_header is unset: bail out
@@ -143,21 +219,21 @@ function! s:getCflags(ft, ck, opts) " {{{2
         let flags = get(a:opts, 'main_flags', '')
     endif
 
-    let flags .= ' ' . s:getCheckerVar('g', a:ft, a:ck, 'compiler_options', '') . ' ' . s:getIncludeDirs(a:ft)
+    let flags .= ' ' . s:_get_checker_var('g', a:ft, a:ck, 'compiler_options', '') . ' ' . s:_get_include_dirs(a:ft)
 
     " check if the user manually set some cflags
-    let b_cflags = s:getCheckerVar('b', a:ft, a:ck, 'cflags', '')
+    let b_cflags = s:_get_checker_var('b', a:ft, a:ck, 'cflags', '')
     if b_cflags == ''
         " check whether to search for include files at all
-        if !s:getCheckerVar('g', a:ft, a:ck, 'no_include_search', 0)
+        if !s:_get_checker_var('g', a:ft, a:ck, 'no_include_search', 0)
             if a:ft ==# 'c' || a:ft ==# 'cpp'
                 " refresh the include file search if desired
-                if s:getCheckerVar('g', a:ft, a:ck, 'auto_refresh_includes', 0)
-                    let flags .= ' ' . s:searchHeaders()
+                if s:_get_checker_var('g', a:ft, a:ck, 'auto_refresh_includes', 0)
+                    let flags .= ' ' . s:_search_headers()
                 else
                     " search for header includes if not cached already
                     if !exists('b:syntastic_' . a:ft . '_includes')
-                        let b:syntastic_{a:ft}_includes = s:searchHeaders()
+                        let b:syntastic_{a:ft}_includes = s:_search_headers()
                     endif
                     let flags .= ' ' . b:syntastic_{a:ft}_includes
                 endif
@@ -169,7 +245,7 @@ function! s:getCflags(ft, ck, opts) " {{{2
     endif
 
     " add optional config file parameters
-    let config_file = s:getCheckerVar('g', a:ft, a:ck, 'config_file', '.syntastic_' . a:ft . '_config')
+    let config_file = s:_get_checker_var('g', a:ft, a:ck, 'config_file', '.syntastic_' . a:ft . '_config')
     let flags .= ' ' . syntastic#c#ReadConfig(config_file)
 
     return flags
@@ -177,7 +253,7 @@ endfunction " }}}2
 
 " get the gcc include directory argument depending on the default
 " includes and the optional user-defined 'g:syntastic_c_include_dirs'
-function! s:getIncludeDirs(filetype) " {{{2
+function! s:_get_include_dirs(filetype) " {{{2
     let include_dirs = []
 
     if a:filetype =~# '\v^%(c|cpp|objc|objcpp)$' &&
@@ -195,7 +271,7 @@ endfunction " }}}2
 
 " search the first 100 lines for include statements that are
 " given in the handlers dictionary
-function! s:searchHeaders() " {{{2
+function! s:_search_headers() " {{{2
     let includes = ''
     let files = []
     let found = []
@@ -221,7 +297,7 @@ function! s:searchHeaders() " {{{2
     " search included headers
     for hfile in files
         if hfile != ''
-            let filename = expand('%:p:h') . syntastic#util#Slash() . hfile
+            let filename = expand('%:p:h', 1) . syntastic#util#Slash() . hfile
 
             try
                 let lines = readfile(filename, '', 100)
@@ -250,69 +326,6 @@ function! s:searchHeaders() " {{{2
     return includes
 endfunction " }}}2
 
-" try to find library with 'pkg-config'
-" search possible libraries from first to last given
-" argument until one is found
-function! syntastic#c#checkPKG(name, ...) " {{{2
-    if executable('pkg-config')
-        if !has_key(s:cflags, a:name)
-            for pkg in a:000
-                let pkg_flags = system('pkg-config --cflags ' . pkg)
-                " since we cannot necessarily trust the pkg-config exit code
-                " we have to check for an error output as well
-                if v:shell_error == 0 && pkg_flags !~? 'not found'
-                    let pkg_flags = ' ' . substitute(pkg_flags, "\n", '', '')
-                    let s:cflags[a:name] = pkg_flags
-                    return pkg_flags
-                endif
-            endfor
-        else
-            return s:cflags[a:name]
-        endif
-    endif
-    return ''
-endfunction " }}}2
-
-" try to find PHP includes with 'php-config'
-function! syntastic#c#checkPHP() " {{{2
-    if executable('php-config')
-        if !has_key(s:cflags, 'php')
-            let s:cflags['php'] = system('php-config --includes')
-            let s:cflags['php'] = ' ' . substitute(s:cflags['php'], "\n", '', '')
-        endif
-        return s:cflags['php']
-    endif
-    return ''
-endfunction " }}}2
-
-" try to find the ruby headers with 'rbconfig'
-function! syntastic#c#checkRuby() " {{{2
-    if executable('ruby')
-        if !has_key(s:cflags, 'ruby')
-            let s:cflags['ruby'] = system('ruby -r rbconfig -e ' .
-                \ '''puts RbConfig::CONFIG["rubyhdrdir"] || RbConfig::CONFIG["archdir"]''')
-            let s:cflags['ruby'] = substitute(s:cflags['ruby'], "\n", '', '')
-            let s:cflags['ruby'] = ' -I' . s:cflags['ruby']
-        endif
-        return s:cflags['ruby']
-    endif
-    return ''
-endfunction " }}}2
-
-" try to find the python headers with distutils
-function! syntastic#c#checkPython() " {{{2
-    if executable('python')
-        if !has_key(s:cflags, 'python')
-            let s:cflags['python'] = system('python -c ''from distutils import ' .
-                \ 'sysconfig; import sys; sys.stdout.write(sysconfig.get_python_inc())''')
-            let s:cflags['python'] = substitute(s:cflags['python'], "\n", '', '')
-            let s:cflags['python'] = ' -I' . s:cflags['python']
-        endif
-        return s:cflags['python']
-    endif
-    return ''
-endfunction " }}}2
-
 " }}}1
 
 " default include directories
@@ -324,7 +337,7 @@ let s:default_includes = [
     \ '..' . syntastic#util#Slash() . 'include',
     \ '..' . syntastic#util#Slash() . 'includes' ]
 
-call s:init()
+call s:_init()
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/bundle/syntastic/autoload/syntastic/log.vim
+++ b/bundle/syntastic/autoload/syntastic/log.vim
@@ -61,12 +61,12 @@ endfunction " }}}2
 " @vimlint(EVL102, 0, l:OLD_VAR)
 
 function! syntastic#log#debug(level, msg, ...) " {{{2
-    if !s:isDebugEnabled(a:level)
+    if !s:_isDebugEnabled(a:level)
         return
     endif
 
-    let leader = s:logTimestamp()
-    call s:logRedirect(1)
+    let leader = s:_log_timestamp()
+    call s:_logRedirect(1)
 
     if a:0 > 0
         " filter out dictionary functions
@@ -77,73 +77,73 @@ function! syntastic#log#debug(level, msg, ...) " {{{2
         echomsg leader . a:msg
     endif
 
-    call s:logRedirect(0)
+    call s:_logRedirect(0)
 endfunction " }}}2
 
 function! syntastic#log#debugShowOptions(level, names) " {{{2
-    if !s:isDebugEnabled(a:level)
+    if !s:_isDebugEnabled(a:level)
         return
     endif
 
-    let leader = s:logTimestamp()
-    call s:logRedirect(1)
+    let leader = s:_log_timestamp()
+    call s:_logRedirect(1)
 
     let vlist = copy(type(a:names) == type("") ? [a:names] : a:names)
     if !empty(vlist)
         call map(vlist, "'&' . v:val . ' = ' . strtrans(string(eval('&' . v:val)))")
         echomsg leader . join(vlist, ', ')
     endif
-    call s:logRedirect(0)
+    call s:_logRedirect(0)
 endfunction " }}}2
 
 function! syntastic#log#debugShowVariables(level, names) " {{{2
-    if !s:isDebugEnabled(a:level)
+    if !s:_isDebugEnabled(a:level)
         return
     endif
 
-    let leader = s:logTimestamp()
-    call s:logRedirect(1)
+    let leader = s:_log_timestamp()
+    call s:_logRedirect(1)
 
     let vlist = type(a:names) == type("") ? [a:names] : a:names
     for name in vlist
-        let msg = s:formatVariable(name)
+        let msg = s:_format_variable(name)
         if msg != ''
             echomsg leader . msg
         endif
     endfor
 
-    call s:logRedirect(0)
+    call s:_logRedirect(0)
 endfunction " }}}2
 
 function! syntastic#log#debugDump(level) " {{{2
-    if !s:isDebugEnabled(a:level)
+    if !s:_isDebugEnabled(a:level)
         return
     endif
 
-    call syntastic#log#debugShowVariables( a:level, sort(keys(g:syntastic_defaults)) )
+    call syntastic#log#debugShowVariables( a:level, sort(keys(g:_SYNTASTIC_DEFAULTS)) )
 endfunction " }}}2
 
 " }}}1
 
 " Private functions {{{1
 
-function! s:isDebugEnabled_smart(level) " {{{2
+function! s:_isDebugEnabled_smart(level) " {{{2
     return and(g:syntastic_debug, a:level)
 endfunction " }}}2
 
-function! s:isDebugEnabled_dumb(level) " {{{2
+function! s:_isDebugEnabled_dumb(level) " {{{2
     " poor man's bit test for bit N, assuming a:level == 2**N
     return (g:syntastic_debug / a:level) % 2
 endfunction " }}}2
 
-let s:isDebugEnabled = function(exists('*and') ? 's:isDebugEnabled_smart' : 's:isDebugEnabled_dumb')
-lockvar s:isDebugEnabled
+let s:_isDebugEnabled = function(exists('*and') ? 's:_isDebugEnabled_smart' : 's:_isDebugEnabled_dumb')
+lockvar s:_isDebugEnabled
 
-function! s:logRedirect(on) " {{{2
+function! s:_logRedirect(on) " {{{2
     if exists("g:syntastic_debug_file")
         if a:on
             try
-                execute 'redir >> ' . fnameescape(expand(g:syntastic_debug_file))
+                execute 'redir >> ' . fnameescape(expand(g:syntastic_debug_file, 1))
             catch /\m^Vim\%((\a\+)\)\=:/
                 silent! redir END
                 unlet g:syntastic_debug_file
@@ -154,11 +154,15 @@ function! s:logRedirect(on) " {{{2
     endif
 endfunction " }}}2
 
-function! s:logTimestamp() " {{{2
-    return 'syntastic: ' . split(reltimestr(reltime(g:syntastic_start)))[0] . ': '
+" }}}1
+
+" Utilities {{{1
+
+function! s:_log_timestamp() " {{{2
+    return 'syntastic: ' . split(reltimestr(reltime(g:_SYNTASTIC_START)))[0] . ': '
 endfunction " }}}2
 
-function! s:formatVariable(name) " {{{2
+function! s:_format_variable(name) " {{{2
     let vals = []
     if exists('g:syntastic_' . a:name)
         call add(vals, 'g:syntastic_' . a:name . ' = ' . strtrans(string(g:syntastic_{a:name})))

--- a/bundle/syntastic/autoload/syntastic/postprocess.vim
+++ b/bundle/syntastic/autoload/syntastic/postprocess.vim
@@ -46,6 +46,25 @@ function! syntastic#postprocess#filterForeignErrors(errors) " {{{2
     return filter(copy(a:errors), 'get(v:val, "bufnr") == ' . bufnr(''))
 endfunction " }}}2
 
+" make sure line numbers are not past end of buffers
+" XXX: this loads all referenced buffers in memory
+function! syntastic#postprocess#guards(errors) " {{{2
+    let buffers = syntastic#util#unique(map(filter(copy(a:errors), 'v:val["valid"]'), 'str2nr(v:val["bufnr"])'))
+
+    let guards = {}
+    for b in buffers
+        let guards[b] = len(getbufline(b, 1, '$'))
+    endfor
+
+    for e in a:errors
+        if e['valid'] && e['lnum'] > guards[e['bufnr']]
+            let e['lnum'] = guards[e['bufnr']]
+        endif
+    endfor
+
+    return a:errors
+endfunction " }}}2
+
 " }}}1
 
 let &cpo = s:save_cpo

--- a/bundle/syntastic/autoload/syntastic/preprocess.vim
+++ b/bundle/syntastic/autoload/syntastic/preprocess.vim
@@ -30,7 +30,7 @@ endfunction " }}}2
 
 function! syntastic#preprocess#checkstyle(errors) " {{{2
     let out = []
-    let fname = expand('%')
+    let fname = expand('%', 1)
     for err in a:errors
         if match(err, '\m<error\>') > -1
             let line = str2nr(matchstr(err, '\m\<line="\zs\d\+\ze"'))
@@ -59,6 +59,70 @@ function! syntastic#preprocess#cppcheck(errors) " {{{2
     return map(copy(a:errors), 'substitute(v:val, ''\v^\[[^]]+\]\zs( -\> \[[^]]+\])+\ze:'', "", "")')
 endfunction " }}}2
 
+" @vimlint(EVL102, 1, l:true)
+" @vimlint(EVL102, 1, l:false)
+" @vimlint(EVL102, 1, l:null)
+function! syntastic#preprocess#flow(errors) " {{{2
+    " JSON artifacts
+    let true = 1
+    let false = 0
+    let null = ''
+
+    " A hat tip to Marc Weber for this trick
+    " http://stackoverflow.com/questions/17751186/iterating-over-a-string-in-vimscript-or-parse-a-json-file/19105763#19105763
+    try
+        let errs = eval(join(a:errors, ''))
+    catch
+        let errs = {}
+    endtry
+
+    let out = []
+    if type(errs) == type({}) && has_key(errs, 'errors') && type(errs['errors']) == type([])
+        for e in errs['errors']
+            if type(e) == type({}) && has_key(e, 'message') && type(e['message']) == type([]) && len(e['message'])
+                let m = e['message'][0]
+                let t = e['message'][1:]
+
+                try
+                    let msg =
+                        \ m['path'] . ':' .
+                        \ m['line'] . ':' .
+                        \ m['start'] . ':' .
+                        \ (m['line'] ==# m['endline'] ? m['end'] . ':' : '') .
+                        \ ' ' . m['descr']
+
+                    if len(t)
+                        let msg .= ' ' . join(map(t,
+                            \ 'v:val["descr"] . " (" . v:val["path"] . ":" . v:val["line"] . ":" . v:val["start"] . ' .
+                            \ '"," . (v:val["line"] !=# v:val["endline"] ? v:val["endline"] . ":" : "") . ' .
+                            \ 'v:val["end"] . ")"'))
+                    endif
+
+                    let msg = substitute(msg, '\r', '', 'g')
+                    let msg = substitute(msg, '\n', ' ', 'g')
+
+                    call add(out, msg)
+                catch /\m^Vim\%((\a\+)\)\=:E716/
+                    call syntastic#log#warn('checker javascript/flow: unknown error format')
+                    let out = []
+                    break
+                endtry
+            else
+                call syntastic#log#warn('checker javascript/flow: unknown error format')
+                let out = []
+                break
+            endif
+        endfor
+    else
+        call syntastic#log#warn('checker javascript/flow: unknown error format')
+    endif
+
+    return out
+endfunction " }}}2
+" @vimlint(EVL102, 0, l:true)
+" @vimlint(EVL102, 0, l:false)
+" @vimlint(EVL102, 0, l:null)
+
 function! syntastic#preprocess#killEmpty(errors) " {{{2
     return filter(copy(a:errors), 'v:val != ""')
 endfunction " }}}2
@@ -67,7 +131,7 @@ function! syntastic#preprocess#perl(errors) " {{{2
     let out = []
 
     for e in a:errors
-        let parts = matchlist(e, '\v^(.*)\sat\s(.*)\sline\s(\d+)(.*)$')
+        let parts = matchlist(e, '\v^(.*)\sat\s(.{-})\sline\s(\d+)(.*)$')
         if !empty(parts)
             call add(out, parts[2] . ':' . parts[3] . ':' . parts[1] . parts[4])
         endif
@@ -75,6 +139,62 @@ function! syntastic#preprocess#perl(errors) " {{{2
 
     return syntastic#util#unique(out)
 endfunction " }}}2
+
+" @vimlint(EVL102, 1, l:true)
+" @vimlint(EVL102, 1, l:false)
+" @vimlint(EVL102, 1, l:null)
+function! syntastic#preprocess#prospector(errors) " {{{2
+    " JSON artifacts
+    let true = 1
+    let false = 0
+    let null = ''
+
+    " A hat tip to Marc Weber for this trick
+    " http://stackoverflow.com/questions/17751186/iterating-over-a-string-in-vimscript-or-parse-a-json-file/19105763#19105763
+    try
+        let errs = eval(join(a:errors, ''))
+    catch
+        let errs = {}
+    endtry
+
+    let out = []
+    if type(errs) == type({}) && has_key(errs, 'messages') && type(errs['messages']) == type([])
+        for e in errs['messages']
+            if type(e) == type({})
+                try
+                    if e['source'] ==# 'pylint'
+                        let e['location']['character'] += 1
+                    endif
+
+                    let msg =
+                        \ e['location']['path'] . ':' .
+                        \ e['location']['line'] . ':' .
+                        \ e['location']['character'] . ': ' .
+                        \ e['code'] . ' ' .
+                        \ e['message'] . ' ' .
+                        \ '[' . e['source'] . ']'
+
+                    call add(out, msg)
+                catch /\m^Vim\%((\a\+)\)\=:E716/
+                    call syntastic#log#warn('checker python/prospector: unknown error format')
+                    let out = []
+                    break
+                endtry
+            else
+                call syntastic#log#warn('checker python/prospector: unknown error format')
+                let out = []
+                break
+            endif
+        endfor
+    else
+        call syntastic#log#warn('checker python/prospector: unknown error format')
+    endif
+
+    return out
+endfunction " }}}2
+" @vimlint(EVL102, 0, l:true)
+" @vimlint(EVL102, 0, l:false)
+" @vimlint(EVL102, 0, l:null)
 
 function! syntastic#preprocess#rparse(errors) " {{{2
     let errlist = copy(a:errors)

--- a/bundle/syntastic/doc/syntastic.txt
+++ b/bundle/syntastic/doc/syntastic.txt
@@ -34,6 +34,7 @@ CONTENTS                                                  *syntastic-contents*
         5.1.Choosing which checkers to use.........|syntastic-filetype-checkers|
         5.2.Choosing the executable................|syntastic-config-exec|
         5.3.Configuring specific checkers..........|syntastic-config-makeprg|
+        5.4.Sorting errors.........................|syntastic-config-sort|
     6.Notes........................................|syntastic-notes|
         6.1.Handling of composite filetypes........|syntastic-composite|
         6.2.Editing files over network.............|syntastic-netrw|
@@ -44,6 +45,7 @@ CONTENTS                                                  *syntastic-contents*
         6.7.Using syntastic with the fizsh shell...|syntastic-fizsh|
         6.8.Interaction with Eclim.................|syntastic-eclim|
         6.9.Interaction with vim-virtualenv........|syntastic-vim-virtualenv|
+        6.10.Interaction with vim-auto-save........|syntastic-vim-auto-save|
     7.About........................................|syntastic-about|
     8.License......................................|syntastic-license|
 
@@ -67,7 +69,7 @@ Take a look at the wiki for a list of supported filetypes and checkers:
     https://github.com/scrooloose/syntastic/wiki/Syntax-Checkers
 
 Note: This doc only deals with using syntastic. To learn how to write syntax
-checker integrations, see the guide on the github wiki:
+checker integrations, see the guide on the GitHub wiki:
 
     https://github.com/scrooloose/syntastic/wiki/Syntax-Checker-Guide
 
@@ -78,16 +80,17 @@ Syntastic comes preconfigured with a default list of enabled checkers per
 filetype. This list is kept reasonably short to prevent slowing down Vim or
 trying to use conflicting checkers.
 
-You can see the list checkers available for the current filetype with the
+You can see the list of checkers available for the current filetype with the
 |:SyntasticInfo| command.
 
-If you want to override the configured list of checkers for a filetype then
-see |syntastic-checker-options| for details. You can also change the arguments
-passed to a specific checker as well.
+You probably want to override the configured list of checkers for the
+filetypes you use, and also change the arguments passed to specific checkers
+to suit your needs. See |syntastic-checker-options| for details.
 
-Use |:SyntasticCheck| to manually check right now. Use |:SyntasticToggleMode|
-to switch between active (checking on writing the buffer) and passive (manual)
-checking.
+Use |:SyntasticCheck| to manually check right now. Use |:Errors| to open the
+|location-list| window, and |:lclose| to close it. You can clear the error
+list with |:SyntasticReset|, and you can use |:SyntasticToggleMode| to switch
+between active (checking on writing the buffer) and passive (manual) checking.
 
 ==============================================================================
 2. Functionality provided                            *syntastic-functionality*
@@ -155,13 +158,22 @@ Example: >
     highlight SyntasticErrorLine guibg=#2f0000
 <
 ------------------------------------------------------------------------------
-2.3. The error window                         *:Errors* *syntastic-error-window*
+2.3. The error window                                   *syntastic-error-window*
 
-You can use the :Errors command to display the errors for the current buffer
+You can use the |:Errors| command to display the errors for the current buffer
 in the |location-list|.
 
-Note that when you use :Errors, the current location list is overwritten with
-Syntastic's own location list.
+Note that when you use |:Errors| the current location list is overwritten with
+Syntastic's own location list. The location list is also overwritten when
+|syntastic_auto_jump| is non-zero and the cursor has to jump to an issue.
+
+By default syntastic doesn't fill the |location-list| with the errors found by
+the checkers, in order to reduce clashes with other plugins. Consequently, if
+you run |:lopen| or |:lwindow| rather than |:Errors| to open the error window you
+wouldn't see syntastic's list of errors. If you insist on using |:lopen| or
+|:lwindow| you should either run |:SyntasticSetLoclist| after running the checks,
+or set |syntastic_always_populate_loc_list| which tells syntastic to update the
+|location-list| automatically.
 
 ------------------------------------------------------------------------------
 2.4. Error highlighting                               *syntastic-highlighting*
@@ -198,7 +210,8 @@ disable generation of these labels by turning off '|syntastic_id_checkers|'.
 If |'syntastic_sort_aggregated_errors'| is set (which is the default), messages
 in the aggregated list are grouped by file, then sorted by line number, then
 type, then column number.  Otherwise messages produced by the same checker are
-grouped together.
+grouped together, and sorting within each group is decided by the variables
+|'syntastic_<filetype>_<checker>_sort'|.
 
 ------------------------------------------------------------------------------
 2.6 Filtering errors                              *syntastic-filtering-errors*
@@ -212,10 +225,13 @@ See also: |'syntastic_<filetype>_<checker>_quiet_messages'|.
 ==============================================================================
 3. Commands                                               *syntastic-commands*
 
-:Errors                                                     *:SyntasticErrors*
+:Errors                                                              *:Errors*
 
 When errors have been detected, use this command to pop up the |location-list|
 and display the error messages.
+
+Please note that the |:Errors| command overwrites the current location list with
+syntastic's own location list.
 
 :SyntasticToggleMode                                    *:SyntasticToggleMode*
 
@@ -239,7 +255,7 @@ the order specified.  The rules of |syntastic_aggregate_errors| still apply.
 Example: >
     :SyntasticCheck flake8 pylint
 <
-:SyntasticInfo                                               *:SyntasticInfo*
+:SyntasticInfo                                                *:SyntasticInfo*
 
 The command takes an optional argument, and outputs information about the
 checkers available for the filetype named by said argument, or for the current
@@ -303,9 +319,22 @@ messages grouped by checker output, set this variable to 0. >
 <
                                               *'syntastic_echo_current_error'*
 Default: 1
-If enabled, syntastic will echo the error associated with the current line to
-the command window. If multiple errors are found, the first will be used. >
+If enabled, syntastic will echo current error to the command window. If
+multiple errors are found on the same line, |syntastic_cursor_columns| is used
+to decide which one is shown. >
     let g:syntastic_echo_current_error = 1
+<
+                                                  *'syntastic_cursor_columns'*
+Default: 1
+This option controls which errors are echoed to the command window if
+|syntastic_echo_current_error| is set and multiple errors are found on the same
+line. When the option is enabled, the first error corresponding to the current
+column is show. Otherwise, the first error on the current line is echoed,
+regardless of the cursor position on the current line.
+
+When dealing with very large lists of errors, disabling this option can speed
+up navigation significantly: >
+    let g:syntastic_cursor_column = 0
 <
                                                     *'syntastic_enable_signs'*
 Default: 1
@@ -354,12 +383,17 @@ when saving or opening a file.
 When set to 0 the cursor won't jump automatically. >
     let g:syntastic_auto_jump = 0
 <
-When set to 1 the cursor will always jump to the first issue detected. >
+When set to 1 the cursor will always jump to the first issue detected,
+regardless of type. >
     let g:syntastic_auto_jump = 1
 <
 When set to 2 the cursor will jump to the first issue detected, but only if
 this issue is an error. >
     let g:syntastic_auto_jump = 2
+<
+When set to 3 the cursor will jump to the first error detected, if any. If
+all issues detected are warnings, the cursor won't jump. >
+    let g:syntastic_auto_jump = 3
 <
                                                    *'syntastic_auto_loc_list'*
 Default: 2
@@ -396,8 +430,9 @@ Default: {}
 Use this option to map non-standard filetypes to standard ones.  Corresponding
 checkers are mapped accordingly, which allows syntastic to check files with
 non-standard filetypes: >
-    let g:syntastic_filetype_map = { "latex": "tex",
-                                   \ "gentoo-metadata": "xml" }
+    let g:syntastic_filetype_map = {
+        \ "latex": "tex",
+        \ "gentoo-metadata": "xml" }
 <
 Composite filetypes can also be mapped to simple types, which disables the
 default behaviour of running both checkers against the input file: >
@@ -407,15 +442,15 @@ default behaviour of running both checkers against the input file: >
 Default: { "mode": "active",
            "active_filetypes": [],
            "passive_filetypes": [] }
-
 Use this option to fine tune when automatic syntax checking is done (or not
 done).
 
 The option should be set to something like: >
 
-    let g:syntastic_mode_map = { "mode": "active",
-                               \ "active_filetypes": ["ruby", "php"],
-                               \ "passive_filetypes": ["puppet"] }
+    let g:syntastic_mode_map = {
+        \ "mode": "active",
+        \ "active_filetypes": ["ruby", "php"],
+        \ "passive_filetypes": ["puppet"] }
 <
 "mode" can be mapped to one of two values - "active" or "passive". When set
 to "active", syntastic does automatic checking whenever a buffer is saved or
@@ -431,31 +466,49 @@ the "passive_filetypes" array ("active_filetypes" is ignored).
 If any of "mode", "active_filetypes", or "passive_filetypes" are left
 unspecified, they default to values above.
 
+If local variable |'b:syntastic_mode'| is defined its value takes precedence
+over all calculations involving |'syntastic_mode_map'| for the corresponding
+buffer.
+
 At runtime, the |:SyntasticToggleMode| command can be used to switch between
 active and passive modes.
 
+                                                          *'b:syntastic_mode'*
+Default: unset
+Only the local form |'b:syntastic_mode'| is used. When set to either "active"
+or "passive", it takes precedence over |'syntastic_mode_map'| when deciding
+whether the corresponding buffer should be checked automatically.
+
                                                   *'syntastic_quiet_messages'*
 Default: {}
-
 Use this option to filter out some of the messages produced by checkers.  The
 option should be set to something like: >
-    let g:syntastic_quiet_messages = { "level": "warnings",
-                                     \ "type":  "style",
-                                     \ "regex": '\m\[C03\d\d\]',
-                                     \ "file":  ['\m^/usr/include/', '\m\c\.h$'] }
+    let g:syntastic_quiet_messages = {
+        \ "!level":  "errors",
+        \ "type":    "style",
+        \ "regex":   '\m\[C03\d\d\]',
+        \ "file:p":  ['\m^/usr/include/', '\m\c\.h$'] }
 <
 Each element turns off messages matching the patterns specified by the
 corresponding value. Values are lists, but if a list consist of a single
-element you can omit adding the brackets (e.g. you can write "style" instead
-of ["style"]). Elements with values [] or '' are ignored (this is useful for
+element you may omit the brackets (e.g. you may write "style" instead of
+["style"]). Elements with values [] or '' are ignored (this is useful for
 overriding filters, cf. |filter-overrides|).
 
     "level" - takes one of two values, "warnings" or "errors"
     "type"  - can be either "syntax" or "style"
     "regex" - is matched against the messages' text as a case insensitive
               |regular-expression|
-    "file"  - is matched against the filename the error refers to, as a case
-              sensitive |regular-expression|.
+    "file"  - is matched against the filenames the messages refer to, as a
+              case sensitive |regular-expression|.
+
+If a key is prefixed by an exclamation mark "!", the corresponding filter is
+negated (i.e. the above example silences all messages that are NOT errors).
+
+The "file" key may be followed by one or more filename modifiers (see
+|filename-modifiers|). The modifiers are applied to the filenames the messages
+refer to before matching against the value (i.e. in the above example the full
+path of the issues are matched against '\m^/usr/include/' and '\m\c\.h$').
 
 If |'syntastic_id_checkers'| is set, filters are applied before error messages
 are labeled with the names of the checkers that created them.
@@ -506,6 +559,12 @@ statusline: >
 If the buffer had 2 warnings, starting on line 5 then this would appear: >
     [Warn: 5 #2]
 <
+                                                   *'b:syntastic_skip_checks'*
+Default: unset
+Only the local form |'b:syntastic_skip_checks'| is used. When set to a true
+value, no checks are run against the corresponding buffer. Example: >
+    let b:syntastic_skip_checks = 1
+<
                                                     *'syntastic_full_redraws'*
 Default: 0 in GUI Vim and MacVim, 1 otherwise
 Controls whether syntastic calls |:redraw| or |:redraw!| for screen redraws.
@@ -513,16 +572,24 @@ Changing it can in principle make screen redraws smoother, but it can also
 cause screen to flicker, or cause ghost characters. Leaving it to the default
 should be safe.
 
+                                                     *'syntastic_exit_checks'*
+Default: 0 when running under "cmd.exe" on Windows, 1 otherwise
+Syntastic attempts to catch abnormal termination conditions from checkers by
+looking at their exit codes. The "cmd.exe" shell on Windows make these checks
+meaningless, by returning 1 to Vim when the checkers exit with non-zero codes.
+The above variable can be used to disable exit code checks in syntastic.
+
                                                            *'syntastic_debug'*
 Default: 0
 Set this to the sum of one or more of the following flags to enable
 debugging:
 
-     1 - trace checker calls
+     1 - trace general workflow
      2 - dump location lists
      4 - trace notifiers
      8 - trace autocommands
     16 - dump options
+    32 - trace running of specific checkers
 
 Example: >
     let g:syntastic_debug = 1
@@ -580,11 +647,19 @@ Use |:SyntasticInfo| to see which checkers are available for a given filetype.
 5.2 Choosing the executable                            *syntastic-config-exec*
 
                                        *'syntastic_<filetype>_<checker>_exec'*
-The executable used by a checker is normally defined automatically, when the
-checkers is registered. You can however override it by setting the variable
+The executable run by a checker is normally defined automatically, when the
+checker is registered. You can however override it, by setting the variable
 'g:syntastic_<filetype>_<checker>_exec': >
     let g:syntastic_ruby_mri_exec = '~/bin/ruby2'
 <
+This variable has a local version, 'b:syntastic_<filetype>_<checker>_exec',
+which takes precedence over the global one in the corresponding buffer.
+
+                                                *'b:syntastic_<checker>_exec'*
+And there is also a local variable named 'b:syntastic_<checker>_exec', which
+takes precedence over both 'b:syntastic_<filetype>_<checker>_exec' and
+'g:syntastic_<filetype>_<checker>_exec' in the buffers where it is defined.
+
 ------------------------------------------------------------------------------
 5.3 Configuring specific checkers                   *syntastic-config-makeprg*
 
@@ -609,21 +684,20 @@ have local versions 'b:syntastic_<filetype>_<checker-name>_<option-name>',
 which take precedence over the global ones in the corresponding buffers.
 
 If one of these variables has a non-empty default and you want it to be empty,
-you can set it to a space, e.g.: >
-    let g:syntastic_javascript_jslint_args = " "
+you can set it to an empty string, e.g.: >
+    let g:syntastic_javascript_jslint_args = ""
 <
-(setting it to an empty string doesn't work, for implementation reasons).
-
                                         *'syntastic_<filetype>_<checker>_exe'*
 The 'exe' is normally the same as the 'exec' attribute described above, in
 which case it may be omitted. However, you can use it to add environment
-variables or additional parameters, e.g. to tell the mri checker to use KANJI
-encoding you could do something like this: >
-    let g:syntastic_ruby_mri_exe = 'RUBYOPT="-Ke" ruby'
+variables, or to change the way the checker is run. For example this setup
+allows you to run PC-Lint under Wine emulation on Linux: >
+    let  g:syntastic_c_pc_lint_exec = "wine"
+    let  g:syntastic_c_pc_lint_exe = "wine c:/path/to/lint-nt.exe"
 <
 To override the args and the tail: >
-    let g:syntastic_ruby_mri_args = "--my --args --here"
-    let g:syntastic_ruby_mri_tail = "> /tmp/my-output-file-biatch"
+    let g:syntastic_c_pc_lint_args = "-w5 -Iz:/usr/include/linux"
+    let g:syntastic_c_pc_lint_tail = "2>/dev/null"
 <
 The general form of the override options is: >
     syntastic_<filetype>_<checker>_<option-name>
@@ -638,10 +712,30 @@ options that can be set, these are usually documented in the wiki:
 In the same vein, 'g:syntastic_<filetype>_<checker-name>_quiet_messages' can
 be used to restrict message filters to messages produced by specific checkers.
 Example: >
-    let g:syntastic_python_pylama_quiet_messages = { "type":  "style",
-                                                   \ "regex": '\m\[C03\d\d\]' }
+    let g:syntastic_python_pylama_quiet_messages = {
+        \ "type":  "style",
+        \ "regex": '\m\[C03\d\d\]' }
 <
 See |syntastic_quiet_messages| for the syntax.
+
+------------------------------------------------------------------------------
+5.4 Sorting errors                                     *syntastic-config-sort*
+
+                                       *'syntastic_<filetype>_<checker>_sort'*
+Syntastic may decide to group the errors produced by some checkers by file,
+then sort them by line number, then by type, then by column number. If you'd
+prefer to see the errors in the order in which they are output by the external
+checker you can set the variable |'g:syntastic_<filetype>_<checker>_sort'| to 0.
+
+Alternatively, if syntastic doesn't reorder the errors produced by a checker
+but you'd like it to sort them, you can set the same variable to 1.
+
+There is also a local version |'b:syntastic_<filetype>_<checker>_sort'| of
+this variable, that takes precedence over it in the buffers where it is
+defined.
+
+For aggregated lists (see |syntastic-aggregating-errors|) these variables are
+ignored if |syntastic_sort_aggregated_errors| is set (which is the default).
 
 ==============================================================================
 6. Notes                                                     *syntastic-notes*
@@ -680,7 +774,7 @@ for python in syntastic (see |syntastic_mode_map|), or disable lint checks in
 
 Syntastic can be used together with the 'YouCompleteMe' Vim plugin (see
 http://valloric.github.io/YouCompleteMe/).  However, by default 'YouCompleteMe'
-disables syntastic"s checkers for the "c", "cpp", "objc", and "objcpp"
+disables syntastic's checkers for the "c", "cpp", "objc", and "objcpp"
 filetypes, in order to allow its own checkers to run.  If you want to use YCM's
 identifier completer but still run syntastic's checkers for those filetypes you
 have to set |ycm_show_diagnostics_ui| to 0. E.g.: >
@@ -722,11 +816,15 @@ interactive features of 'fizsh'. Using a more traditional shell such as "zsh",
 ------------------------------------------------------------------------------
 6.8. Interaction with Eclim                                  *syntastic-eclim*
 
-As far as syntastic is concerned there shouldn't be any compatibility problems
-with the 'Eclim' Vim plugin (see http://eclim.org/). However, at the time of
-this writing there are several reports that 'Eclim' triggers a bug in Vim that
-makes syntastic forget some of its configuration parameters. No solutions or
-workarounds are known for now.
+Syntastic can be used together with 'Eclim' (see http://eclim.org/). However,
+by default Eclim disables syntastic's checks for the filetypes it supports, in
+order to run its own validation. If you'd prefer to use Eclim but still run
+syntastic's checks, set |g:EclimFileTypeValidate| to 0: >
+    let g:EclimFileTypeValidate = 0
+<
+It is also possible to re-enable syntastic checks only for some filetypes, and
+run Eclim's validation for others. Please consult Eclim's documentation for
+details.
 
 ------------------------------------------------------------------------------
 6.9. Interaction with vim-virtualenv                *syntastic-vim-virtualenv*
@@ -736,13 +834,26 @@ in Python virtual environments activated by 'vim-virtualenv' (see
 https://github.com/jmcantrell/vim-virtualenv).  This is a limitation of
 'vim-virtualenv'.
 
+------------------------------------------------------------------------------
+6.10. Interaction with vim-auto-save                 *syntastic-vim-auto-save*
+
+At the time of this writing, syntastic checks in active mode are not triggered
+by 'vim-auto-save' (see https://github.com/907th/vim-auto-save). The reason is
+a limitation in 'vim-auto-save', namely a missing flag to an 'autocmd' (see
+|autocmd-nested|). Fortunately it's pretty easy to achieve a similar effect
+without 'vim-auto-save'': >
+    augroup syntastic
+        autocmd CursorHold * nested update
+    augroup END
+    set updatetime=200
+<
 ==============================================================================
 7. About                                                     *syntastic-about*
 
 The core maintainers of syntastic are:
-    Martin Grenfell (github: scrooloose)
-    Gregor Uhlenheuer (github: kongo2002)
-    LCD 047 (github: lcd047)
+    Martin Grenfell (GitHub: scrooloose)
+    Gregor Uhlenheuer (GitHub: kongo2002)
+    LCD 047 (GitHub: lcd047)
 
 Find the latest version of syntastic at:
 

--- a/bundle/syntastic/doc/tags
+++ b/bundle/syntastic/doc/tags
@@ -1,15 +1,20 @@
+'b:syntastic_<checker>_exec'	syntastic.txt	/*'b:syntastic_<checker>_exec'*
 'b:syntastic_checkers'	syntastic.txt	/*'b:syntastic_checkers'*
+'b:syntastic_mode'	syntastic.txt	/*'b:syntastic_mode'*
+'b:syntastic_skip_checks'	syntastic.txt	/*'b:syntastic_skip_checks'*
 'g:syntastic_<filetype>_checkers'	syntastic.txt	/*'g:syntastic_<filetype>_checkers'*
 'syntastic_<filetype>_<checker>_<option>'	syntastic.txt	/*'syntastic_<filetype>_<checker>_<option>'*
 'syntastic_<filetype>_<checker>_exe'	syntastic.txt	/*'syntastic_<filetype>_<checker>_exe'*
 'syntastic_<filetype>_<checker>_exec'	syntastic.txt	/*'syntastic_<filetype>_<checker>_exec'*
 'syntastic_<filetype>_<checker>_quiet_messages'	syntastic.txt	/*'syntastic_<filetype>_<checker>_quiet_messages'*
+'syntastic_<filetype>_<checker>_sort'	syntastic.txt	/*'syntastic_<filetype>_<checker>_sort'*
 'syntastic_aggregate_errors'	syntastic.txt	/*'syntastic_aggregate_errors'*
 'syntastic_always_populate_loc_list'	syntastic.txt	/*'syntastic_always_populate_loc_list'*
 'syntastic_auto_jump'	syntastic.txt	/*'syntastic_auto_jump'*
 'syntastic_auto_loc_list'	syntastic.txt	/*'syntastic_auto_loc_list'*
 'syntastic_check_on_open'	syntastic.txt	/*'syntastic_check_on_open'*
 'syntastic_check_on_wq'	syntastic.txt	/*'syntastic_check_on_wq'*
+'syntastic_cursor_columns'	syntastic.txt	/*'syntastic_cursor_columns'*
 'syntastic_debug'	syntastic.txt	/*'syntastic_debug'*
 'syntastic_debug_file'	syntastic.txt	/*'syntastic_debug_file'*
 'syntastic_echo_current_error'	syntastic.txt	/*'syntastic_echo_current_error'*
@@ -17,6 +22,7 @@
 'syntastic_enable_highlighting'	syntastic.txt	/*'syntastic_enable_highlighting'*
 'syntastic_enable_signs'	syntastic.txt	/*'syntastic_enable_signs'*
 'syntastic_error_symbol'	syntastic.txt	/*'syntastic_error_symbol'*
+'syntastic_exit_checks'	syntastic.txt	/*'syntastic_exit_checks'*
 'syntastic_extra_filetypes'	syntastic.txt	/*'syntastic_extra_filetypes'*
 'syntastic_filetype_map'	syntastic.txt	/*'syntastic_filetype_map'*
 'syntastic_full_redraws'	syntastic.txt	/*'syntastic_full_redraws'*
@@ -32,7 +38,6 @@
 'syntastic_warning_symbol'	syntastic.txt	/*'syntastic_warning_symbol'*
 :Errors	syntastic.txt	/*:Errors*
 :SyntasticCheck	syntastic.txt	/*:SyntasticCheck*
-:SyntasticErrors	syntastic.txt	/*:SyntasticErrors*
 :SyntasticInfo	syntastic.txt	/*:SyntasticInfo*
 :SyntasticReset	syntastic.txt	/*:SyntasticReset*
 :SyntasticSetLoclist	syntastic.txt	/*:SyntasticSetLoclist*
@@ -46,6 +51,7 @@ syntastic-commands	syntastic.txt	/*syntastic-commands*
 syntastic-composite	syntastic.txt	/*syntastic-composite*
 syntastic-config-exec	syntastic.txt	/*syntastic-config-exec*
 syntastic-config-makeprg	syntastic.txt	/*syntastic-config-makeprg*
+syntastic-config-sort	syntastic.txt	/*syntastic-config-sort*
 syntastic-contents	syntastic.txt	/*syntastic-contents*
 syntastic-eclim	syntastic.txt	/*syntastic-eclim*
 syntastic-error-signs	syntastic.txt	/*syntastic-error-signs*
@@ -65,6 +71,7 @@ syntastic-powershell	syntastic.txt	/*syntastic-powershell*
 syntastic-pymode	syntastic.txt	/*syntastic-pymode*
 syntastic-quickstart	syntastic.txt	/*syntastic-quickstart*
 syntastic-statusline-flag	syntastic.txt	/*syntastic-statusline-flag*
+syntastic-vim-auto-save	syntastic.txt	/*syntastic-vim-auto-save*
 syntastic-vim-virtualenv	syntastic.txt	/*syntastic-vim-virtualenv*
 syntastic-ycm	syntastic.txt	/*syntastic-ycm*
 syntastic.txt	syntastic.txt	/*syntastic.txt*

--- a/bundle/syntastic/plugin/syntastic.vim
+++ b/bundle/syntastic/plugin/syntastic.vim
@@ -15,53 +15,63 @@ endif
 let g:loaded_syntastic_plugin = 1
 
 if has('reltime')
-    let g:syntastic_start = reltime()
-    lockvar! g:syntastic_start
+    let g:_SYNTASTIC_START = reltime()
+    lockvar! g:_SYNTASTIC_START
 endif
 
-let g:syntastic_version = '3.4.0-117'
-lockvar g:syntastic_version
+let g:_SYNTASTIC_VERSION = '3.5.0-72'
+lockvar g:_SYNTASTIC_VERSION
 
 " Sanity checks {{{1
 
-for s:feature in ['autocmd', 'eval', 'modify_fname', 'quickfix', 'reltime', 'user_commands']
+for s:feature in [
+            \ 'autocmd',
+            \ 'eval',
+            \ 'file_in_path',
+            \ 'modify_fname',
+            \ 'quickfix',
+            \ 'reltime',
+            \ 'user_commands'
+        \ ]
     if !has(s:feature)
         call syntastic#log#error("need Vim compiled with feature " . s:feature)
         finish
     endif
 endfor
 
-let s:running_windows = syntastic#util#isRunningWindows()
-lockvar s:running_windows
+let s:_running_windows = syntastic#util#isRunningWindows()
+lockvar s:_running_windows
 
-if !s:running_windows && executable('uname')
+if !s:_running_windows && executable('uname')
     try
-        let s:uname = system('uname')
+        let s:_uname = system('uname')
     catch /\m^Vim\%((\a\+)\)\=:E484/
-        call syntastic#log#error("your shell " . &shell . " doesn't use traditional UNIX syntax for redirections")
+        call syntastic#log#error("your shell " . &shell . " can't handle traditional UNIX syntax for redirections")
         finish
     endtry
-    lockvar s:uname
+    lockvar s:_uname
 endif
 
 " }}}1
 
 " Defaults {{{1
 
-let g:syntastic_defaults = {
+let g:_SYNTASTIC_DEFAULTS = {
         \ 'aggregate_errors':         0,
         \ 'always_populate_loc_list': 0,
         \ 'auto_jump':                0,
         \ 'auto_loc_list':            2,
-        \ 'bash_hack':                1,
+        \ 'bash_hack':                0,
         \ 'check_on_open':            0,
         \ 'check_on_wq':              1,
+        \ 'cursor_columns':           1,
         \ 'debug':                    0,
         \ 'echo_current_error':       1,
         \ 'enable_balloons':          1,
         \ 'enable_highlighting':      1,
         \ 'enable_signs':             1,
         \ 'error_symbol':             '>>',
+        \ 'exit_checks':              !(s:_running_windows && &shell =~? '\m\<cmd\.exe$'),
         \ 'filetype_map':             {},
         \ 'full_redraws':             !(has('gui_running') || has('gui_macvim')),
         \ 'id_checkers':              1,
@@ -76,11 +86,11 @@ let g:syntastic_defaults = {
         \ 'style_warning_symbol':     'S>',
         \ 'warning_symbol':           '>>'
     \ }
-lockvar! g:syntastic_defaults
+lockvar! g:_SYNTASTIC_DEFAULTS
 
-for s:key in keys(g:syntastic_defaults)
+for s:key in keys(g:_SYNTASTIC_DEFAULTS)
     if !exists('g:syntastic_' . s:key)
-        let g:syntastic_{s:key} = g:syntastic_defaults[s:key]
+        let g:syntastic_{s:key} = copy(g:_SYNTASTIC_DEFAULTS[s:key])
     endif
 endfor
 
@@ -100,7 +110,7 @@ endif
 
 " Debug {{{1
 
-let s:debug_dump_options = [
+let s:_DEBUG_DUMP_OPTIONS = [
         \ 'shell',
         \ 'shellcmdflag',
         \ 'shellpipe',
@@ -111,21 +121,23 @@ let s:debug_dump_options = [
         \ 'shellxquote'
     \ ]
 if v:version > 703 || (v:version == 703 && has('patch446'))
-    call add(s:debug_dump_options, 'shellxescape')
+    call add(s:_DEBUG_DUMP_OPTIONS, 'shellxescape')
 endif
-lockvar! s:debug_dump_options
+lockvar! s:_DEBUG_DUMP_OPTIONS
 
 " debug constants
-let     g:SyntasticDebugTrace         = 1
-lockvar g:SyntasticDebugTrace
-let     g:SyntasticDebugLoclist       = 2
-lockvar g:SyntasticDebugLoclist
-let     g:SyntasticDebugNotifications = 4
-lockvar g:SyntasticDebugNotifications
-let     g:SyntasticDebugAutocommands  = 8
-lockvar g:SyntasticDebugAutocommands
-let     g:SyntasticDebugVariables     = 16
-lockvar g:SyntasticDebugVariables
+let     g:_SYNTASTIC_DEBUG_TRACE         = 1
+lockvar g:_SYNTASTIC_DEBUG_TRACE
+let     g:_SYNTASTIC_DEBUG_LOCLIST       = 2
+lockvar g:_SYNTASTIC_DEBUG_LOCLIST
+let     g:_SYNTASTIC_DEBUG_NOTIFICATIONS = 4
+lockvar g:_SYNTASTIC_DEBUG_NOTIFICATIONS
+let     g:_SYNTASTIC_DEBUG_AUTOCOMMANDS  = 8
+lockvar g:_SYNTASTIC_DEBUG_AUTOCOMMANDS
+let     g:_SYNTASTIC_DEBUG_VARIABLES     = 16
+lockvar g:_SYNTASTIC_DEBUG_VARIABLES
+let     g:_SYNTASTIC_DEBUG_CHECKERS      = 32
+lockvar g:_SYNTASTIC_DEBUG_CHECKERS
 
 " }}}1
 
@@ -142,7 +154,7 @@ let s:modemap = g:SyntasticModeMap.Instance()
 " @vimlint(EVL103, 1, a:argLead)
 function! s:CompleteCheckerName(argLead, cmdLine, cursorPos) " {{{2
     let checker_names = []
-    for ft in s:resolveFiletypes()
+    for ft in s:_resolve_filetypes([])
         call extend(checker_names, s:registry.getNamesOfAvailableCheckers(ft))
     endfor
     return join(checker_names, "\n")
@@ -162,27 +174,56 @@ endfunction " }}}2
 " @vimlint(EVL103, 0, a:cmdLine)
 " @vimlint(EVL103, 0, a:argLead)
 
-command! SyntasticToggleMode call s:ToggleMode()
-command! -nargs=* -complete=custom,s:CompleteCheckerName SyntasticCheck
-            \ call s:UpdateErrors(0, <f-args>) <bar>
-            \ call syntastic#util#redraw(g:syntastic_full_redraws)
-command! Errors call s:ShowLocList()
-command! -nargs=? -complete=custom,s:CompleteFiletypes SyntasticInfo
-            \ call s:modemap.modeInfo(<f-args>) |
-            \ call s:registry.echoInfoFor(s:resolveFiletypes(<f-args>))
-command! SyntasticReset
-            \ call s:ClearCache() |
-            \ call s:notifiers.refresh(g:SyntasticLoclist.New([]))
-command! SyntasticSetLoclist call g:SyntasticLoclist.current().setloclist()
+command! -nargs=* -complete=custom,s:CompleteCheckerName SyntasticCheck call SyntasticCheck(<f-args>)
+command! -nargs=? -complete=custom,s:CompleteFiletypes   SyntasticInfo  call SyntasticInfo(<f-args>)
+command! Errors              call SyntasticErrors()
+command! SyntasticReset      call SyntasticReset()
+command! SyntasticToggleMode call SyntasticToggleMode()
+command! SyntasticSetLoclist call SyntasticSetLoclist()
 
 " }}}1
 
-" Autocommands and hooks {{{1
+" Public API {{{1
+
+function! SyntasticCheck(...) " {{{2
+    call s:UpdateErrors(0, a:000)
+    call syntastic#util#redraw(g:syntastic_full_redraws)
+endfunction " }}}2
+
+function! SyntasticInfo(...) " {{{2
+    call s:modemap.modeInfo(a:000)
+    call s:registry.echoInfoFor(s:_resolve_filetypes(a:000))
+    call s:_explain_skip(a:000)
+endfunction " }}}2
+
+function! SyntasticErrors() " {{{2
+    call g:SyntasticLoclist.current().show()
+endfunction " }}}2
+
+function! SyntasticReset() " {{{2
+    call s:ClearCache()
+    call s:notifiers.refresh(g:SyntasticLoclist.New([]))
+endfunction " }}}2
+
+function! SyntasticToggleMode() " {{{2
+    call s:modemap.toggleMode()
+    call s:ClearCache()
+    call s:notifiers.refresh(g:SyntasticLoclist.New([]))
+    call s:modemap.echoMode()
+endfunction " }}}2
+
+function! SyntasticSetLoclist() " {{{2
+    call g:SyntasticLoclist.current().setloclist()
+endfunction " }}}2
+
+" }}}1
+
+" Autocommands {{{1
 
 augroup syntastic
-    autocmd BufReadPost * call s:BufReadPostHook()
+    autocmd BufReadPost  * call s:BufReadPostHook()
     autocmd BufWritePost * call s:BufWritePostHook()
-    autocmd BufEnter * call s:BufEnterHook()
+    autocmd BufEnter     * call s:BufEnterHook()
 augroup END
 
 if v:version > 703 || (v:version == 703 && has('patch544'))
@@ -194,20 +235,20 @@ endif
 
 function! s:BufReadPostHook() " {{{2
     if g:syntastic_check_on_open
-        call syntastic#log#debug(g:SyntasticDebugAutocommands,
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_AUTOCOMMANDS,
             \ 'autocmd: BufReadPost, buffer ' . bufnr("") . ' = ' . string(bufname(str2nr(bufnr("")))))
-        call s:UpdateErrors(1)
+        call s:UpdateErrors(1, [])
     endif
 endfunction " }}}2
 
 function! s:BufWritePostHook() " {{{2
-    call syntastic#log#debug(g:SyntasticDebugAutocommands,
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_AUTOCOMMANDS,
         \ 'autocmd: BufWritePost, buffer ' . bufnr("") . ' = ' . string(bufname(str2nr(bufnr("")))))
-    call s:UpdateErrors(1)
+    call s:UpdateErrors(1, [])
 endfunction " }}}2
 
 function! s:BufEnterHook() " {{{2
-    call syntastic#log#debug(g:SyntasticDebugAutocommands,
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_AUTOCOMMANDS,
         \ 'autocmd: BufEnter, buffer ' . bufnr("") . ' = ' . string(bufname(str2nr(bufnr("")))) .
         \ ', &buftype = ' . string(&buftype))
     if &buftype == ''
@@ -219,17 +260,19 @@ function! s:BufEnterHook() " {{{2
         let loclist = filter(copy(getloclist(0)), 'v:val["valid"] == 1')
         let owner = str2nr(getbufvar(bufnr(""), 'syntastic_owner_buffer'))
         let buffers = syntastic#util#unique(map(loclist, 'v:val["bufnr"]') + (owner ? [owner] : []))
-        if !empty(loclist) && empty(filter( buffers, 'syntastic#util#bufIsActive(v:val)' ))
+        if get(w:, 'syntastic_loclist_set', 0) && !empty(loclist) && empty(filter( buffers, 'syntastic#util#bufIsActive(v:val)' ))
             call SyntasticLoclistHide()
         endif
     endif
 endfunction " }}}2
 
 function! s:QuitPreHook() " {{{2
-    call syntastic#log#debug(g:SyntasticDebugAutocommands,
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_AUTOCOMMANDS,
         \ 'autocmd: QuitPre, buffer ' . bufnr("") . ' = ' . string(bufname(str2nr(bufnr("")))))
-    let b:syntastic_skip_checks = !g:syntastic_check_on_wq
-    call SyntasticLoclistHide()
+    let b:syntastic_skip_checks = get(b:, 'syntastic_skip_checks', 0) || !syntastic#util#var('check_on_wq')
+    if get(w:, 'syntastic_loclist_set', 0)
+        call SyntasticLoclistHide()
+    endif
 endfunction " }}}2
 
 " }}}1
@@ -237,40 +280,46 @@ endfunction " }}}2
 " Main {{{1
 
 "refresh and redraw all the error info for this buf when saving or reading
-function! s:UpdateErrors(auto_invoked, ...) " {{{2
-    call syntastic#log#debugShowVariables(g:SyntasticDebugTrace, 'version')
-    call syntastic#log#debugShowOptions(g:SyntasticDebugTrace, s:debug_dump_options)
-    call syntastic#log#debugDump(g:SyntasticDebugVariables)
-    call syntastic#log#debug(g:SyntasticDebugTrace, 'UpdateErrors' . (a:auto_invoked ? ' (auto)' : '') .
-        \ ': ' . (a:0 ? join(a:000) : 'default checkers'))
-    if s:skipFile()
+function! s:UpdateErrors(auto_invoked, checker_names) " {{{2
+    call syntastic#log#debugShowVariables(g:_SYNTASTIC_DEBUG_TRACE, 'version')
+    call syntastic#log#debugShowOptions(g:_SYNTASTIC_DEBUG_TRACE, s:_DEBUG_DUMP_OPTIONS)
+    call syntastic#log#debugDump(g:_SYNTASTIC_DEBUG_VARIABLES)
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_TRACE, 'UpdateErrors' . (a:auto_invoked ? ' (auto)' : '') .
+        \ ': ' . (len(a:checker_names) ? join(a:checker_names) : 'default checkers'))
+    if s:_skip_file()
         return
     endif
 
     call s:modemap.synch()
-    let run_checks = !a:auto_invoked || s:modemap.allowsAutoChecking(&filetype)
+    let run_checks = !a:auto_invoked || s:modemap.doAutoChecking()
     if run_checks
-        call s:CacheErrors(a:000)
+        call s:CacheErrors(a:checker_names)
     endif
 
     let loclist = g:SyntasticLoclist.current()
 
+    if exists('*SyntasticCheckHook')
+        call SyntasticCheckHook(loclist.getRaw())
+    endif
+
     " populate loclist and jump {{{3
-    let do_jump = syntastic#util#var('auto_jump')
+    let do_jump = syntastic#util#var('auto_jump') + 0
     if do_jump == 2
-        let first = loclist.getFirstIssue()
-        let type = get(first, 'type', '')
-        let do_jump = type ==? 'E'
+        let do_jump = loclist.getFirstError(1)
+    elseif do_jump == 3
+        let do_jump = loclist.getFirstError()
+    elseif 0 > do_jump || do_jump > 3
+        let do_jump = 0
     endif
 
     let w:syntastic_loclist_set = 0
     if syntastic#util#var('always_populate_loc_list') || do_jump
-        call syntastic#log#debug(g:SyntasticDebugNotifications, 'loclist: setloclist (new)')
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'loclist: setloclist (new)')
         call setloclist(0, loclist.getRaw())
         let w:syntastic_loclist_set = 1
         if run_checks && do_jump && !loclist.isEmpty()
-            call syntastic#log#debug(g:SyntasticDebugNotifications, 'loclist: jump')
-            silent! lrewind
+            call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'loclist: jump')
+            execute 'silent! lrewind ' . do_jump
 
             " XXX: Vim doesn't call autocmd commands in a predictible
             " order, which can lead to missing filetype when jumping
@@ -294,18 +343,18 @@ endfunction " }}}2
 
 "detect and cache all syntax errors in this buffer
 function! s:CacheErrors(checker_names) " {{{2
-    call syntastic#log#debug(g:SyntasticDebugTrace, 'CacheErrors: ' .
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_TRACE, 'CacheErrors: ' .
         \ (len(a:checker_names) ? join(a:checker_names) : 'default checkers'))
     call s:ClearCache()
     let newLoclist = g:SyntasticLoclist.New([])
 
-    if !s:skipFile()
+    if !s:_skip_file()
         " debug logging {{{3
-        call syntastic#log#debugShowVariables(g:SyntasticDebugTrace, 'aggregate_errors')
-        call syntastic#log#debug(g:SyntasticDebugTrace, 'getcwd() = ' . getcwd())
+        call syntastic#log#debugShowVariables(g:_SYNTASTIC_DEBUG_TRACE, 'aggregate_errors')
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_TRACE, 'getcwd() = ' . getcwd())
         " }}}3
 
-        let filetypes = s:resolveFiletypes()
+        let filetypes = s:_resolve_filetypes([])
         let aggregate_errors = syntastic#util#var('aggregate_errors') || len(filetypes) > 1
         let decorate_errors = aggregate_errors && syntastic#util#var('id_checkers')
         let sort_aggregated_errors = aggregate_errors && syntastic#util#var('sort_aggregated_errors')
@@ -320,12 +369,12 @@ function! s:CacheErrors(checker_names) " {{{2
         for checker in clist
             let cname = checker.getFiletype() . '/' . checker.getName()
             if !checker.isAvailable()
-                call syntastic#log#debug(g:SyntasticDebugTrace, 'CacheErrors: Checker ' . cname . ' is not available')
+                call syntastic#log#debug(g:_SYNTASTIC_DEBUG_TRACE, 'CacheErrors: Checker ' . cname . ' is not available')
                 let unavailable_checkers += 1
                 continue
             endif
 
-            call syntastic#log#debug(g:SyntasticDebugTrace, 'CacheErrors: Invoking checker: ' . cname)
+            call syntastic#log#debug(g:_SYNTASTIC_DEBUG_TRACE, 'CacheErrors: Invoking checker: ' . cname)
 
             let loclist = checker.getLocList()
 
@@ -334,9 +383,9 @@ function! s:CacheErrors(checker_names) " {{{2
                     call loclist.decorate(cname)
                 endif
                 call add(names, cname)
-                if checker.getWantSort() && !sort_aggregated_errors
+                if checker.wantSort() && !sort_aggregated_errors
                     call loclist.sort()
-                    call syntastic#log#debug(g:SyntasticDebugLoclist, 'sorted:', loclist)
+                    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_LOCLIST, 'sorted:', loclist)
                 endif
 
                 let newLoclist = newLoclist.extend(loclist)
@@ -369,31 +418,19 @@ function! s:CacheErrors(checker_names) " {{{2
                     call syntastic#log#warn('checkers ' . join(a:checker_names, ', ') . ' are not available')
                 endif
             else
-                call syntastic#log#debug(g:SyntasticDebugTrace, 'CacheErrors: no checkers available for ' . &filetype)
+                call syntastic#log#debug(g:_SYNTASTIC_DEBUG_TRACE, 'CacheErrors: no checkers available for ' . &filetype)
             endif
         endif
         " }}}3
 
-        call syntastic#log#debug(g:SyntasticDebugLoclist, 'aggregated:', newLoclist)
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_LOCLIST, 'aggregated:', newLoclist)
         if sort_aggregated_errors
             call newLoclist.sort()
-            call syntastic#log#debug(g:SyntasticDebugLoclist, 'sorted:', newLoclist)
+            call syntastic#log#debug(g:_SYNTASTIC_DEBUG_LOCLIST, 'sorted:', newLoclist)
         endif
     endif
 
     call newLoclist.deploy()
-endfunction " }}}2
-
-function! s:ToggleMode() " {{{2
-    call s:modemap.toggleMode()
-    call s:ClearCache()
-    call s:UpdateErrors(1)
-    call s:modemap.echoMode()
-endfunction " }}}2
-
-"display the cached errors for this buf in the location list
-function! s:ShowLocList() " {{{2
-    call g:SyntasticLoclist.current().show()
 endfunction " }}}2
 
 "Emulates the :lmake command. Sets up the make environment according to the
@@ -416,10 +453,9 @@ endfunction " }}}2
 "   'returns' - a list of valid exit codes for the checker
 " @vimlint(EVL102, 1, l:env_save)
 function! SyntasticMake(options) " {{{2
-    call syntastic#log#debug(g:SyntasticDebugTrace, 'SyntasticMake: called with options:', a:options)
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_TRACE, 'SyntasticMake: called with options:', a:options)
 
     " save options and locale env variables {{{3
-    let old_shell = &shell
     let old_shellredir = &shellredir
     let old_local_errorformat = &l:errorformat
     let old_errorformat = &errorformat
@@ -428,7 +464,7 @@ function! SyntasticMake(options) " {{{2
     let old_lc_all = $LC_ALL
     " }}}3
 
-    call s:bashHack()
+    call s:_bash_hack()
 
     if has_key(a:options, 'errorformat')
         let &errorformat = a:options['errorformat']
@@ -464,61 +500,78 @@ function! SyntasticMake(options) " {{{2
     endif
     " }}}3
 
-    call syntastic#log#debug(g:SyntasticDebugLoclist, 'checker output:', err_lines)
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_LOCLIST, 'checker output:', err_lines)
 
-    if has_key(a:options, 'Preprocess')
-        let err_lines = call(a:options['Preprocess'], [err_lines])
-        call syntastic#log#debug(g:SyntasticDebugLoclist, 'preprocess (external):', err_lines)
-    elseif has_key(a:options, 'preprocess')
-        let err_lines = call('syntastic#preprocess#' . a:options['preprocess'], [err_lines])
-        call syntastic#log#debug(g:SyntasticDebugLoclist, 'preprocess:', err_lines)
+    " Does it still make sense to go on?
+    let bailout =
+        \ syntastic#util#var('exit_checks') &&
+        \ has_key(a:options, 'returns') &&
+        \ index(a:options['returns'], v:shell_error) == -1
+
+    if !bailout
+        if has_key(a:options, 'Preprocess')
+            let err_lines = call(a:options['Preprocess'], [err_lines])
+            call syntastic#log#debug(g:_SYNTASTIC_DEBUG_LOCLIST, 'preprocess (external):', err_lines)
+        elseif has_key(a:options, 'preprocess')
+            let err_lines = call('syntastic#preprocess#' . a:options['preprocess'], [err_lines])
+            call syntastic#log#debug(g:_SYNTASTIC_DEBUG_LOCLIST, 'preprocess:', err_lines)
+        endif
+        lgetexpr err_lines
+
+        let errors = deepcopy(getloclist(0))
+
+        if has_key(a:options, 'cwd')
+            execute 'lcd ' . fnameescape(old_cwd)
+        endif
+
+        try
+            silent lolder
+        catch /\m^Vim\%((\a\+)\)\=:E380/
+            " E380: At bottom of quickfix stack
+            call setloclist(0, [], 'r')
+        catch /\m^Vim\%((\a\+)\)\=:E776/
+            " E776: No location list
+            " do nothing
+        endtry
+    else
+        let errors = []
     endif
-    lgetexpr err_lines
-
-    let errors = deepcopy(getloclist(0))
-
-    if has_key(a:options, 'cwd')
-        execute 'lcd ' . fnameescape(old_cwd)
-    endif
-
-    silent! lolder
 
     " restore options {{{3
     let &errorformat = old_errorformat
     let &l:errorformat = old_local_errorformat
     let &shellredir = old_shellredir
-    let &shell = old_shell
     " }}}3
 
-    if !s:running_windows && (s:uname() =~ "FreeBSD" || s:uname() =~ "OpenBSD")
+    if !s:_running_windows && (s:_os_name() =~ "FreeBSD" || s:_os_name() =~ "OpenBSD")
         call syntastic#util#redraw(g:syntastic_full_redraws)
     endif
 
-    call syntastic#log#debug(g:SyntasticDebugLoclist, 'raw loclist:', errors)
-
-    if has_key(a:options, 'returns') && index(a:options['returns'], v:shell_error) == -1
+    if bailout
         throw 'Syntastic: checker error'
     endif
 
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_LOCLIST, 'raw loclist:', errors)
+
     if has_key(a:options, 'defaults')
-        call s:addToErrors(errors, a:options['defaults'])
+        call s:_add_to_errors(errors, a:options['defaults'])
     endif
 
     " Add subtype info if present.
     if has_key(a:options, 'subtype')
-        call s:addToErrors(errors, { 'subtype': a:options['subtype'] })
+        call s:_add_to_errors(errors, { 'subtype': a:options['subtype'] })
     endif
 
     if has_key(a:options, 'Postprocess') && !empty(a:options['Postprocess'])
         for rule in a:options['Postprocess']
             let errors = call(rule, [errors])
         endfor
-        call syntastic#log#debug(g:SyntasticDebugLoclist, 'postprocess (external):', errors)
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_LOCLIST, 'postprocess (external):', errors)
     elseif has_key(a:options, 'postprocess') && !empty(a:options['postprocess'])
         for rule in a:options['postprocess']
             let errors = call('syntastic#postprocess#' . rule, [errors])
         endfor
-        call syntastic#log#debug(g:SyntasticDebugLoclist, 'postprocess:', errors)
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_LOCLIST, 'postprocess:', errors)
     endif
 
     return errors
@@ -537,12 +590,12 @@ endfunction " }}}2
 
 " Utilities {{{1
 
-function! s:resolveFiletypes(...) " {{{2
-    let type = a:0 ? a:1 : &filetype
+function! s:_resolve_filetypes(filetypes) " {{{2
+    let type = len(a:filetypes) ? a:filetypes[0] : &filetype
     return split( get(g:syntastic_filetype_map, type, type), '\m\.' )
 endfunction " }}}2
 
-function! s:ignoreFile(filename) " {{{2
+function! s:_ignore_file(filename) " {{{2
     let fname = fnamemodify(a:filename, ':p')
     for pattern in g:syntastic_ignore_files
         if fname =~# pattern
@@ -553,19 +606,48 @@ function! s:ignoreFile(filename) " {{{2
 endfunction " }}}2
 
 " Skip running in special buffers
-function! s:skipFile() " {{{2
-    let fname = expand('%')
-    let skip = (exists('b:syntastic_skip_checks') ? b:syntastic_skip_checks : 0) ||
-        \ (&buftype != '') || !filereadable(fname) || getwinvar(0, '&diff') ||
-        \ s:ignoreFile(fname) || fnamemodify(fname, ':e') =~? g:syntastic_ignore_extensions
+function! s:_skip_file() " {{{2
+    let fname = expand('%', 1)
+    let skip = get(b:, 'syntastic_skip_checks', 0) || (&buftype != '') ||
+        \ !filereadable(fname) || getwinvar(0, '&diff') || s:_ignore_file(fname) ||
+        \ fnamemodify(fname, ':e') =~? g:syntastic_ignore_extensions
     if skip
-        call syntastic#log#debug(g:SyntasticDebugTrace, 'skipFile: skipping')
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_TRACE, '_skip_file: skipping checks')
     endif
     return skip
 endfunction " }}}2
 
+" Explain why checks will be skipped for the current file
+function! s:_explain_skip(filetypes) " {{{2
+    if empty(a:filetypes) && s:_skip_file()
+        let why = []
+        let fname = expand('%', 1)
+
+        if get(b:, 'syntastic_skip_checks', 0)
+            call add(why, 'b:syntastic_skip_checks set')
+        endif
+        if &buftype != ''
+            call add(why, 'buftype = ' . string(&buftype))
+        endif
+        if !filereadable(fname)
+            call add(why, 'file not readable / not local')
+        endif
+        if getwinvar(0, '&diff')
+            call add(why, 'diff mode')
+        endif
+        if s:_ignore_file(fname)
+            call add(why, 'filename matching g:syntastic_ignore_files')
+        endif
+        if fnamemodify(fname, ':e') =~? g:syntastic_ignore_extensions
+            call add(why, 'extension matching g:syntastic_ignore_extensions')
+        endif
+
+        echomsg 'The current file will not be checked (' . join(why, ', ') . ')'
+    endif
+endfunction " }}}2
+
 " Take a list of errors and add default values to them from a:options
-function! s:addToErrors(errors, options) " {{{2
+function! s:_add_to_errors(errors, options) " {{{2
     for err in a:errors
         for key in keys(a:options)
             if !has_key(err, key) || empty(err[key])
@@ -577,31 +659,30 @@ function! s:addToErrors(errors, options) " {{{2
     return a:errors
 endfunction " }}}2
 
-" The script changes &shellredir and &shell to stop the screen flicking when
-" shelling out to syntax checkers. Not all OSs support the hacks though.
-function! s:bashHack() " {{{2
-    if !exists('s:bash')
-        if !s:running_windows && (s:uname() !~# "FreeBSD") && (s:uname() !~# "OpenBSD")
-            let s:bash =
-                \ executable('/usr/local/bin/bash') ? '/usr/local/bin/bash' :
-                \ executable('/bin/bash') ? '/bin/bash' : ''
-        else
-            let s:bash = ''
+" XXX: Is this still needed?
+" The script changes &shellredir to stop the screen
+" flicking when shelling out to syntax checkers.
+function! s:_bash_hack() " {{{2
+    if g:syntastic_bash_hack
+        if !exists('s:shell_is_bash')
+            let s:shell_is_bash =
+                \ !s:_running_windows &&
+                \ (s:_os_name() !~# "FreeBSD") && (s:_os_name() !~# "OpenBSD") &&
+                \ &shell =~# '\m\<bash$'
         endif
-    endif
 
-    if g:syntastic_bash_hack && s:bash != ''
-        let &shell = s:bash
-        let &shellredir = '&>'
+        if s:shell_is_bash
+            let &shellredir = '&>'
+        endif
     endif
 endfunction " }}}2
 
-function! s:uname() " {{{2
-    if !exists('s:uname')
-        let s:uname = system('uname')
-        lockvar s:uname
+function! s:_os_name() " {{{2
+    if !exists('s:_uname')
+        let s:_uname = system('uname')
+        lockvar s:_uname
     endif
-    return s:uname
+    return s:_uname
 endfunction " }}}2
 
 " }}}1

--- a/bundle/syntastic/plugin/syntastic/autoloclist.vim
+++ b/bundle/syntastic/plugin/syntastic/autoloclist.vim
@@ -13,12 +13,12 @@ function! g:SyntasticAutoloclistNotifier.New() " {{{2
 endfunction " }}}2
 
 function! g:SyntasticAutoloclistNotifier.refresh(loclist) " {{{2
-    call syntastic#log#debug(g:SyntasticDebugNotifications, 'autoloclist: refresh')
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'autoloclist: refresh')
     call g:SyntasticAutoloclistNotifier.AutoToggle(a:loclist)
 endfunction " }}}2
 
 function! g:SyntasticAutoloclistNotifier.AutoToggle(loclist) " {{{2
-    call syntastic#log#debug(g:SyntasticDebugNotifications, 'autoloclist: toggle')
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'autoloclist: toggle')
     if !a:loclist.isEmpty()
         if syntastic#util#var('auto_loc_list') == 1
             call a:loclist.show()

--- a/bundle/syntastic/plugin/syntastic/balloons.vim
+++ b/bundle/syntastic/plugin/syntastic/balloons.vim
@@ -22,20 +22,11 @@ endfunction " }}}2
 
 " Update the error balloons
 function! g:SyntasticBalloonsNotifier.refresh(loclist) " {{{2
-    let b:syntastic_balloons = {}
+    unlet! b:syntastic_private_balloons
     if self.enabled() && !a:loclist.isEmpty()
-        call syntastic#log#debug(g:SyntasticDebugNotifications, 'balloons: refresh')
-        let buf = bufnr('')
-        let issues = filter(a:loclist.copyRaw(), 'v:val["bufnr"] == buf')
-        if !empty(issues)
-            for i in issues
-                if has_key(b:syntastic_balloons, i['lnum'])
-                    let b:syntastic_balloons[i['lnum']] .= "\n" . i['text']
-                else
-                    let b:syntastic_balloons[i['lnum']] = i['text']
-                endif
-            endfor
-            set beval bexpr=SyntasticBalloonsExprNotifier()
+        let b:syntastic_private_balloons = a:loclist.balloons()
+        if !empty(b:syntastic_private_balloons)
+            set ballooneval balloonexpr=SyntasticBalloonsExprNotifier()
         endif
     endif
 endfunction " }}}2
@@ -43,10 +34,11 @@ endfunction " }}}2
 " Reset the error balloons
 " @vimlint(EVL103, 1, a:loclist)
 function! g:SyntasticBalloonsNotifier.reset(loclist) " {{{2
-    let b:syntastic_balloons = {}
+    let b:syntastic_private_balloons = {}
     if has('balloon_eval')
-        call syntastic#log#debug(g:SyntasticDebugNotifications, 'balloons: reset')
-        set nobeval
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'balloons: reset')
+        unlet! b:syntastic_private_balloons
+        set noballooneval
     endif
 endfunction " }}}2
 " @vimlint(EVL103, 0, a:loclist)
@@ -56,10 +48,10 @@ endfunction " }}}2
 " Private functions {{{1
 
 function! SyntasticBalloonsExprNotifier() " {{{2
-    if !exists('b:syntastic_balloons')
+    if !exists('b:syntastic_private_balloons')
         return ''
     endif
-    return get(b:syntastic_balloons, v:beval_lnum, '')
+    return get(b:syntastic_private_balloons, v:beval_lnum, '')
 endfunction " }}}2
 
 " }}}1

--- a/bundle/syntastic/plugin/syntastic/cursor.vim
+++ b/bundle/syntastic/plugin/syntastic/cursor.vim
@@ -18,9 +18,10 @@ endfunction " }}}2
 
 function! g:SyntasticCursorNotifier.refresh(loclist) " {{{2
     if self.enabled() && !a:loclist.isEmpty()
-        call syntastic#log#debug(g:SyntasticDebugNotifications, 'cursor: refresh')
-        let b:syntastic_messages = copy(a:loclist.messages(bufnr('')))
-        let b:oldLine = -1
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'cursor: refresh')
+        let b:syntastic_private_messages = copy(a:loclist.messages(bufnr('')))
+        let b:syntastic_private_line = -1
+        let b:syntastic_cursor_columns = a:loclist.getCursorColumns()
         autocmd! syntastic CursorMoved
         autocmd syntastic CursorMoved * call SyntasticRefreshCursor()
     endif
@@ -28,38 +29,108 @@ endfunction " }}}2
 
 " @vimlint(EVL103, 1, a:loclist)
 function! g:SyntasticCursorNotifier.reset(loclist) " {{{2
-    call syntastic#log#debug(g:SyntasticDebugNotifications, 'cursor: reset')
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'cursor: reset')
     autocmd! syntastic CursorMoved
-    unlet! b:syntastic_messages
-    let b:oldLine = -1
+    unlet! b:syntastic_private_messages
+    let b:syntastic_private_line = -1
 endfunction " }}}2
 " @vimlint(EVL103, 0, a:loclist)
 
 " }}}1
 
-" Private methods {{{1
+" Private functions {{{1
 
-" The following defensive nonsense is needed because of the nature of autocmd
 function! SyntasticRefreshCursor() " {{{2
-    if !exists('b:syntastic_messages') || empty(b:syntastic_messages)
+    if !exists('b:syntastic_private_messages') || empty(b:syntastic_private_messages)
         " file not checked
         return
     endif
 
-    if !exists('b:oldLine')
-        let b:oldLine = -1
+    if !exists('b:syntastic_private_line')
+        let b:syntastic_private_line = -1
     endif
     let l = line('.')
-    if l == b:oldLine
-        return
-    endif
-    let b:oldLine = l
+    let current_messages = get(b:syntastic_private_messages, l, {})
 
-    if has_key(b:syntastic_messages, l)
-        call syntastic#util#wideMsg(b:syntastic_messages[l])
-    else
-        echo
+    if !exists('b:syntastic_cursor_columns')
+        let b:syntastic_cursor_columns = g:syntastic_cursor_columns
     endif
+
+    if b:syntastic_cursor_columns
+        let c = virtcol('.')
+        if !exists('b:syntastic_private_idx')
+            let b:syntastic_private_idx = -1
+        endif
+
+        if s:_is_same_index(l, b:syntastic_private_line, c, b:syntastic_private_idx, current_messages)
+            return
+        else
+            let b:syntastic_private_line = l
+        endif
+
+        if !empty(current_messages)
+            let b:syntastic_private_idx = s:_find_index(c, current_messages)
+            call syntastic#util#wideMsg(current_messages[b:syntastic_private_idx].text)
+        else
+            let b:syntastic_private_idx = -1
+            echo
+        endif
+    else
+        if l == b:syntastic_private_line
+            return
+        endif
+        let b:syntastic_private_line = l
+
+        if !empty(current_messages)
+            call syntastic#util#wideMsg(current_messages[0].text)
+        else
+            echo
+        endif
+    endif
+endfunction " }}}2
+
+" }}}1
+
+" Utilities {{{1
+
+function! s:_is_same_index(line, old_line, column, idx, messages) " {{{2
+    if a:old_line >= 0 && a:line == a:old_line && a:idx >= 0
+        if len(a:messages) <= 1
+            return 1
+        endif
+
+        if a:messages[a:idx].scol <= a:column || a:idx == 0
+            if a:idx == len(a:messages) - 1 || a:column < a:messages[a:idx + 1].scol
+                return 1
+            else
+                return 0
+            endif
+        else
+            return 0
+        endif
+    else
+        return 0
+    endif
+endfunction " }}}2
+
+function! s:_find_index(column, messages) " {{{2
+    let max = len(a:messages) - 1
+    if max == 0
+        return 0
+    endif
+    let min = 0
+
+    " modified binary search: assign index 0 to columns to the left of the first error
+    while min < max - 1
+        let mid = (min + max) / 2
+        if a:column < a:messages[mid].scol
+            let max = mid
+        else
+            let min = mid
+        endif
+    endwhile
+
+    return a:column < a:messages[max].scol ? min : max
 endfunction " }}}2
 
 " }}}1

--- a/bundle/syntastic/plugin/syntastic/highlighting.vim
+++ b/bundle/syntastic/plugin/syntastic/highlighting.vim
@@ -32,7 +32,7 @@ endfunction " }}}2
 " Sets error highlights in the cuirrent window
 function! g:SyntasticHighlightingNotifier.refresh(loclist) " {{{2
     if self.enabled()
-        call syntastic#log#debug(g:SyntasticDebugNotifications, 'highlighting: refresh')
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'highlighting: refresh')
         call self._reset()
         let buf = bufnr('')
         let issues = filter(a:loclist.copyRaw(), 'v:val["bufnr"] == buf')
@@ -63,7 +63,7 @@ endfunction " }}}2
 " @vimlint(EVL103, 1, a:loclist)
 function! g:SyntasticHighlightingNotifier.reset(loclist) " {{{2
     if s:has_highlighting
-        call syntastic#log#debug(g:SyntasticDebugNotifications, 'highlighting: reset')
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'highlighting: reset')
         call self._reset()
     endif
 endfunction " }}}2

--- a/bundle/syntastic/plugin/syntastic/modemap.vim
+++ b/bundle/syntastic/plugin/syntastic/modemap.vim
@@ -38,6 +38,15 @@ function! g:SyntasticModeMap.allowsAutoChecking(filetype) " {{{2
     endif
 endfunction " }}}2
 
+function! g:SyntasticModeMap.doAutoChecking() " {{{2
+    let local_mode = get(b:, 'syntastic_mode', '')
+    if local_mode ==# 'active' || local_mode ==# 'passive'
+        return local_mode ==# 'active'
+    endif
+
+    return self.allowsAutoChecking(&filetype)
+endfunction " }}}2
+
 function! g:SyntasticModeMap.isPassive() " {{{2
     return self._mode ==# 'passive'
 endfunction " }}}2
@@ -62,13 +71,13 @@ function! g:SyntasticModeMap.echoMode() " {{{2
     echo "Syntastic: " . self._mode . " mode enabled"
 endfunction " }}}2
 
-function! g:SyntasticModeMap.modeInfo(...) " {{{2
-    echomsg 'Syntastic version: ' . g:syntastic_version
-    let type = a:0 ? a:1 : &filetype
+function! g:SyntasticModeMap.modeInfo(filetypes) " {{{2
+    echomsg 'Syntastic version: ' . g:_SYNTASTIC_VERSION
+    let type = len(a:filetypes) ? a:filetypes[0] : &filetype
     echomsg 'Info for filetype: ' . type
 
     call self.synch()
-    echomsg 'Mode: ' . self._mode
+    echomsg 'Global mode: ' . self._mode
     if self._mode ==# 'active'
         if len(self._passiveFiletypes)
             let plural = len(self._passiveFiletypes) != 1 ? 's' : ''
@@ -81,6 +90,14 @@ function! g:SyntasticModeMap.modeInfo(...) " {{{2
         endif
     endif
     echomsg 'Filetype ' . type . ' is ' . (self.allowsAutoChecking(type) ? 'active' : 'passive')
+
+    if !len(a:filetypes)
+        if exists('b:syntastic_mode') && (b:syntastic_mode ==# 'active' || b:syntastic_mode ==# 'passive')
+            echomsg 'Local mode: ' . b:syntastic_mode
+        endif
+
+        echomsg 'The current file will ' . (self.doAutoChecking() ? '' : 'not ') . 'be checked automatically'
+    endif
 endfunction " }}}2
 
 " }}}1

--- a/bundle/syntastic/plugin/syntastic/notifiers.vim
+++ b/bundle/syntastic/plugin/syntastic/notifiers.vim
@@ -5,11 +5,11 @@ let g:loaded_syntastic_notifiers = 1
 
 let g:SyntasticNotifiers = {}
 
-let s:notifier_types = ['signs', 'balloons', 'highlighting', 'cursor', 'autoloclist']
-lockvar! s:notifier_types
+let s:_NOTIFIER_TYPES = ['signs', 'balloons', 'highlighting', 'cursor', 'autoloclist']
+lockvar! s:_NOTIFIER_TYPES
 
-let s:persistent_notifiers = ['signs', 'balloons']
-lockvar! s:persistent_notifiers
+let s:_PERSISTENT_NOTIFIERS = ['signs', 'balloons']
+lockvar! s:_PERSISTENT_NOTIFIERS
 
 " Public methods {{{1
 
@@ -28,18 +28,18 @@ function! g:SyntasticNotifiers.refresh(loclist) " {{{2
         return
     endif
 
-    call syntastic#log#debug(g:SyntasticDebugNotifications, 'notifiers: refresh')
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'notifiers: refresh')
     for type in self._enabled_types
         let class = substitute(type, '\m.*', 'Syntastic\u&Notifier', '')
         if !has_key(g:{class}, 'enabled') || self._notifier[type].enabled()
-            if index(s:persistent_notifiers, type) > -1
+            if index(s:_PERSISTENT_NOTIFIERS, type) > -1
                 " refresh only if loclist has changed since last call
-                if !exists('b:syntastic_' . type . '_stamp')
-                    let b:syntastic_{type}_stamp = []
+                if !exists('b:syntastic_private_' . type . '_stamp')
+                    let b:syntastic_private_{type}_stamp = []
                 endif
-                if a:loclist.isNewerThan(b:syntastic_{type}_stamp) || a:loclist.isEmpty()
+                if a:loclist.isNewerThan(b:syntastic_private_{type}_stamp) || a:loclist.isEmpty()
                     call self._notifier[type].refresh(a:loclist)
-                    let b:syntastic_{type}_stamp = syntastic#util#stamp()
+                    let b:syntastic_private_{type}_stamp = syntastic#util#stamp()
                 endif
             else
                 call self._notifier[type].refresh(a:loclist)
@@ -49,7 +49,7 @@ function! g:SyntasticNotifiers.refresh(loclist) " {{{2
 endfunction " }}}2
 
 function! g:SyntasticNotifiers.reset(loclist) " {{{2
-    call syntastic#log#debug(g:SyntasticDebugNotifications, 'notifiers: reset')
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'notifiers: reset')
     for type in self._enabled_types
         let class = substitute(type, '\m.*', 'Syntastic\u&Notifier', '')
 
@@ -61,8 +61,8 @@ function! g:SyntasticNotifiers.reset(loclist) " {{{2
         endif
 
         " also reset stamps
-        if index(s:persistent_notifiers, type) > -1
-            let b:syntastic_{type}_stamp = []
+        if index(s:_PERSISTENT_NOTIFIERS, type) > -1
+            let b:syntastic_private_{type}_stamp = []
         endif
     endfor
 endfunction " }}}2
@@ -73,12 +73,12 @@ endfunction " }}}2
 
 function! g:SyntasticNotifiers._initNotifiers() " {{{2
     let self._notifier = {}
-    for type in s:notifier_types
+    for type in s:_NOTIFIER_TYPES
         let class = substitute(type, '\m.*', 'Syntastic\u&Notifier', '')
         let self._notifier[type] = g:{class}.New()
     endfor
 
-    let self._enabled_types = copy(s:notifier_types)
+    let self._enabled_types = copy(s:_NOTIFIER_TYPES)
 endfunction " }}}2
 
 " }}}1

--- a/bundle/syntastic/plugin/syntastic/signs.vim
+++ b/bundle/syntastic/plugin/syntastic/signs.vim
@@ -36,7 +36,7 @@ function! g:SyntasticSignsNotifier.enabled() " {{{2
 endfunction " }}}2
 
 function! g:SyntasticSignsNotifier.refresh(loclist) " {{{2
-    call syntastic#log#debug(g:SyntasticDebugNotifications, 'signs: refresh')
+    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_NOTIFICATIONS, 'signs: refresh')
     let old_signs = copy(self._bufSignIds())
     if self.enabled()
         call self._signErrors(a:loclist)
@@ -127,10 +127,10 @@ endfunction " }}}2
 
 " Get all the ids of the SyntaxError signs in the buffer
 function! g:SyntasticSignsNotifier._bufSignIds() " {{{2
-    if !exists("b:syntastic_sign_ids")
-        let b:syntastic_sign_ids = []
+    if !exists("b:syntastic_private_sign_ids")
+        let b:syntastic_private_sign_ids = []
     endif
-    return b:syntastic_sign_ids
+    return b:syntastic_private_sign_ids
 endfunction " }}}2
 
 " }}}1

--- a/bundle/syntastic/syntax_checkers/ada/gcc.vim
+++ b/bundle/syntastic/syntax_checkers/ada/gcc.vim
@@ -23,7 +23,7 @@ function! SyntaxCheckers_ada_gcc_IsAvailable() dict
     if !exists('g:syntastic_ada_compiler')
         let g:syntastic_ada_compiler = self.getExec()
     endif
-    return executable(expand(g:syntastic_ada_compiler))
+    return executable(expand(g:syntastic_ada_compiler, 1))
 endfunction
 
 function! SyntaxCheckers_ada_gcc_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/asm/gcc.vim
+++ b/bundle/syntastic/syntax_checkers/asm/gcc.vim
@@ -26,7 +26,7 @@ function! SyntaxCheckers_asm_gcc_IsAvailable() dict
     if !exists('g:syntastic_asm_compiler')
         let g:syntastic_asm_compiler = self.getExec()
     endif
-    return executable(expand(g:syntastic_asm_compiler))
+    return executable(expand(g:syntastic_asm_compiler, 1))
 endfunction
 
 function! SyntaxCheckers_asm_gcc_GetLocList() dict
@@ -41,7 +41,7 @@ endfunction
 
 function! s:GetDialect()
     return exists('g:syntastic_asm_dialect') ? g:syntastic_asm_dialect :
-        \ expand('%:e') ==? 'asm' ? 'intel' : 'att'
+        \ expand('%:e', 1) ==? 'asm' ? 'intel' : 'att'
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/bro/bro.vim
+++ b/bundle/syntastic/syntax_checkers/bro/bro.vim
@@ -18,15 +18,30 @@ let g:loaded_syntastic_bro_bro_checker = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! SyntaxCheckers_bro_bro_GetHighlightRegex(item)
+    let term = matchstr(a:item['text'], '\m at or near "\zs[^"]\+\ze"')
+    return term != '' ? '\V\<' . escape(term, '\') . '\>' : ''
+endfunction
+
 function! SyntaxCheckers_bro_bro_IsAvailable() dict
-    return system(self.getExecEscaped() . ' --help') =~# '--parse-only'
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    if system(self.getExecEscaped() . ' --help') !~# '--parse-only'
+        call self.log('unknown option "--parse-only"')
+        return 0
+    endif
+
+    return 1
 endfunction
 
 function! SyntaxCheckers_bro_bro_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'args_before': '--parse-only' })
 
-    "example: error in ./foo.bro, line 3: unknown identifier banana, at or "near "banana"
+    "example: error in ./foo.bro, line 3: unknown identifier banana, at or near "banana"
     let errorformat =
+        \ 'fatal %trror in %f\, line %l: %m,' .
         \ '%trror in %f\, line %l: %m,' .
         \ '%tarning in %f\, line %l: %m'
 

--- a/bundle/syntastic/syntax_checkers/c/checkpatch.vim
+++ b/bundle/syntastic/syntax_checkers/c/checkpatch.vim
@@ -18,17 +18,19 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_c_checkpatch_IsAvailable() dict
-    call syntastic#log#deprecationWarn('c_checker_checkpatch_location', 'c_checkpatch_exe')
+    call syntastic#log#deprecationWarn('c_checker_checkpatch_location', 'c_checkpatch_exec')
 
-    if !exists('g:syntastic_c_checkpatch_exe') && !executable(self.getExec())
+    if !exists('g:syntastic_c_checkpatch_exec') && !executable(self.getExec())
         if executable('checkpatch')
-            let g:syntastic_c_checkpatch_exe = 'checkpatch'
+            let g:syntastic_c_checkpatch_exec = 'checkpatch'
         elseif executable('./scripts/checkpatch.pl')
-            let g:syntastic_c_checkpatch_exe = fnamemodify('./scripts/checkpatch.pl', ':p')
+            let g:syntastic_c_checkpatch_exec = fnamemodify('./scripts/checkpatch.pl', ':p')
         elseif executable('./scripts/checkpatch')
-            let g:syntastic_c_checkpatch_exe = fnamemodify('./scripts/checkpatch', ':p')
+            let g:syntastic_c_checkpatch_exec = fnamemodify('./scripts/checkpatch', ':p')
         endif
     endif
+
+    call self.log('exec =', self.getExec())
 
     return executable(self.getExec())
 endfunction

--- a/bundle/syntastic/syntax_checkers/c/clang_check.vim
+++ b/bundle/syntastic/syntax_checkers/c/clang_check.vim
@@ -1,0 +1,61 @@
+"============================================================================
+"File:        clang_check.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Benjamin Bannier <bbannier at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists("g:loaded_syntastic_c_clang_check_checker")
+  finish
+endif
+let g:loaded_syntastic_c_clang_check_checker = 1
+
+if !exists('g:syntastic_clang_check_config_file')
+    let g:syntastic_clang_check_config_file = '.syntastic_clang_check_config'
+endif
+
+if !exists('g:syntastic_c_clang_check_sort')
+    let g:syntastic_c_clang_check_sort = 1
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_c_clang_check_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+        \ 'post_args':
+        \   '-- ' .
+        \   syntastic#c#ReadConfig(g:syntastic_clang_check_config_file) . ' ' .
+        \   '-fshow-column ' .
+        \   '-fshow-source-location ' .
+        \   '-fno-caret-diagnostics ' .
+        \   '-fno-color-diagnostics ' .
+        \   '-fdiagnostics-format=clang' })
+
+    let errorformat =
+        \ '%E%f:%l:%c: fatal error: %m,' .
+        \ '%E%f:%l:%c: error: %m,' .
+        \ '%W%f:%l:%c: warning: %m,' .
+        \ '%-G%\m%\%%(LLVM ERROR:%\|No compilation database found%\)%\@!%.%#,' .
+        \ '%E%m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': {'bufnr': bufnr('')},
+        \ 'returns': [0, 1] })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'c',
+    \ 'name': 'clang_check',
+    \ 'exec': 'clang-check'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/c/clang_tidy.vim
+++ b/bundle/syntastic/syntax_checkers/c/clang_tidy.vim
@@ -1,0 +1,61 @@
+"============================================================================
+"File:        clang_tidy.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Benjamin Bannier <bbannier at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists("g:loaded_syntastic_c_clang_tidy_checker")
+  finish
+endif
+let g:loaded_syntastic_c_clang_tidy_checker = 1
+
+if !exists('g:syntastic_clang_tidy_config_file')
+    let g:syntastic_clang_tidy_config_file = '.syntastic_clang_tidy_config'
+endif
+
+if !exists('g:syntastic_c_clang_tidy_sort')
+    let g:syntastic_c_clang_tidy_sort = 1
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_c_clang_tidy_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+        \ 'post_args':
+        \   '-- ' .
+        \   syntastic#c#ReadConfig(g:syntastic_clang_tidy_config_file) . ' ' .
+        \   '-fshow-column ' .
+        \   '-fshow-source-location ' .
+        \   '-fno-caret-diagnostics ' .
+        \   '-fno-color-diagnostics ' .
+        \   '-fdiagnostics-format=clang' })
+
+    let errorformat =
+        \ '%E%f:%l:%c: fatal error: %m,' .
+        \ '%E%f:%l:%c: error: %m,' .
+        \ '%W%f:%l:%c: warning: %m,' .
+        \ '%-G%\m%\%%(LLVM ERROR:%\|No compilation database found%\)%\@!%.%#,' .
+        \ '%E%m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': {'bufnr': bufnr('')},
+        \ 'returns': [0, 1] })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'c',
+    \ 'name': 'clang_tidy',
+    \ 'exec': 'clang-tidy'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/c/cppcheck.vim
+++ b/bundle/syntastic/syntax_checkers/c/cppcheck.vim
@@ -8,13 +8,6 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "============================================================================
-"
-" The setting 'g:syntastic_cppcheck_config_file' allows you to define a file
-" that contains additional compiler arguments like include directories or
-" CFLAGS. The file is expected to contain one option per line. If none is
-" given the filename defaults to '.syntastic_cppcheck_config':
-"
-"   let g:syntastic_cppcheck_config_file = '.config'
 
 if exists("g:loaded_syntastic_c_cppcheck_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/c/gcc.vim
+++ b/bundle/syntastic/syntax_checkers/c/gcc.vim
@@ -26,7 +26,8 @@ function! SyntaxCheckers_c_gcc_IsAvailable() dict
     if !exists('g:syntastic_c_compiler')
         let g:syntastic_c_compiler = executable(self.getExec()) ? self.getExec() : 'clang'
     endif
-    return executable(expand(g:syntastic_c_compiler))
+    call self.log('g:syntastic_c_compiler =', g:syntastic_c_compiler)
+    return executable(expand(g:syntastic_c_compiler, 1))
 endfunction
 
 function! SyntaxCheckers_c_gcc_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/c/pc_lint.vim
+++ b/bundle/syntastic/syntax_checkers/c/pc_lint.vim
@@ -1,0 +1,66 @@
+"============================================================================
+"File:        pc_lint.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Steve Bragg <steve at empresseffects dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists("g:loaded_syntastic_c_pc_lint_checker")
+    finish
+endif
+let g:loaded_syntastic_c_pc_lint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+if !exists('g:syntastic_pc_lint_config_file')
+    let g:syntastic_pc_lint_config_file = 'options.lnt'
+endif
+
+function! SyntaxCheckers_c_pc_lint_GetLocList() dict
+    let config = findfile(g:syntastic_pc_lint_config_file, '.;')
+    call self.log('config =', config)
+
+    " -hFs1         - show filename, add space after messages, try to make message 1 line
+    " -width(0,0)   - make sure there are no line breaks
+    " -t            - set tab size
+    " -v            - turn off verbosity
+    let makeprg = self.makeprgBuild({
+        \ 'args': (filereadable(config) ? syntastic#util#shescape(fnamemodify(config, ':p')) : ''),
+        \ 'args_after': ['-hFs1', '-width(0,0)', '-t' . &tabstop, '-format=%f:%l:%C:%t:%n:%m'] })
+
+    let errorformat =
+        \ '%E%f:%l:%v:Error:%n:%m,' .
+        \ '%W%f:%l:%v:Warning:%n:%m,' .
+        \ '%I%f:%l:%v:Info:%n:%m,' .
+        \ '%-G%.%#'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'postprocess': ['cygwinRemoveCR'] })
+
+    for e in loclist
+        if e['type'] ==? 'I'
+            let e['type'] = 'W'
+            let e['subtype'] = 'Style'
+        endif
+    endfor
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'c',
+    \ 'name': 'pc_lint',
+    \ 'exec': 'lint-nt'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/c/sparse.vim
+++ b/bundle/syntastic/syntax_checkers/c/sparse.vim
@@ -8,13 +8,6 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "============================================================================
-"
-" The setting 'g:syntastic_sparse_config_file' allows you to define a file
-" that contains additional compiler arguments like include directories or
-" CFLAGS. The file is expected to contain one option per line. If none is
-" given the filename defaults to '.syntastic_sparse_config':
-"
-"   let g:syntastic_sparse_config_file = '.config'
 
 if exists("g:loaded_syntastic_c_sparse_checker")
     finish
@@ -33,13 +26,15 @@ function! SyntaxCheckers_c_sparse_GetLocList() dict
         \ 'args': syntastic#c#ReadConfig(g:syntastic_sparse_config_file),
         \ 'args_after': '-ftabstop=' . &ts })
 
-    let errorformat = '%f:%l:%v: %trror: %m,%f:%l:%v: %tarning: %m,'
+    let errorformat =
+        \ '%f:%l:%v: %trror: %m,' .
+        \ '%f:%l:%v: %tarning: %m,'
 
     let loclist = SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'defaults': {'bufnr': bufnr("")},
-        \ 'returns': [0] })
+        \ 'returns': [0, 1] })
     return loclist
 endfunction
 

--- a/bundle/syntastic/syntax_checkers/c/splint.vim
+++ b/bundle/syntastic/syntax_checkers/c/splint.vim
@@ -8,13 +8,6 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "============================================================================
-"
-" The setting 'g:syntastic_splint_config_file' allows you to define a file
-" that contains additional compiler arguments like include directories or
-" CFLAGS. The file is expected to contain one option per line. If none is
-" given the filename defaults to '.syntastic_splint_config':
-"
-"   let g:syntastic_splint_config_file = '.config'
 
 if exists("g:loaded_syntastic_c_splint_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/cabal/cabal.vim
+++ b/bundle/syntastic/syntax_checkers/cabal/cabal.vim
@@ -40,7 +40,7 @@ function! SyntaxCheckers_cabal_cabal_GetLocList() dict
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'cwd': expand('%:p:h'),
+        \ 'cwd': expand('%:p:h', 1),
         \ 'preprocess': 'cabal',
         \ 'defaults': {'bufnr': bufnr('')} })
 endfunction

--- a/bundle/syntastic/syntax_checkers/co/coco.vim
+++ b/bundle/syntastic/syntax_checkers/co/coco.vim
@@ -19,7 +19,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_co_coco_GetLocList() dict
-    let tmpdir = $TMPDIR != '' ? $TMPDIR : $TMP != '' ? $TMP : '/tmp'
+    let tmpdir = syntastic#util#tmpdir()
     let makeprg = self.makeprgBuild({ 'args_after': '-c -o ' . tmpdir })
 
     let errorformat =
@@ -28,9 +28,13 @@ function! SyntaxCheckers_co_coco_GetLocList() dict
         \ '%EFailed at: %f,'.
         \ '%Z%trror: Parse error on line %l: %m'
 
-    return SyntasticMake({
+    let loclist = SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat })
+
+    call syntastic#util#rmrf(tmpdir)
+
+    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/cobol/cobc.vim
+++ b/bundle/syntastic/syntax_checkers/cobol/cobc.vim
@@ -27,7 +27,8 @@ function! SyntaxCheckers_cobol_cobc_IsAvailable() dict
     if !exists('g:syntastic_cobol_compiler')
         let g:syntastic_cobol_compiler = self.getExec()
     endif
-    return executable(expand(g:syntastic_cobol_compiler))
+    call self.log('g:syntastic_cobol_compiler =', g:syntastic_cobol_compiler)
+    return executable(expand(g:syntastic_cobol_compiler, 1))
 endfunction
 
 function! SyntaxCheckers_cobol_cobc_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/coffee/coffee.vim
+++ b/bundle/syntastic/syntax_checkers/coffee/coffee.vim
@@ -22,9 +22,14 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_coffee_coffee_IsAvailable() dict
-    return executable(self.getExec()) &&
-        \ syntastic#util#versionIsAtLeast(syntastic#util#getVersion(
-        \       self.getExecEscaped() . ' --version 2>' . syntastic#util#DevNull()), [1,6,2])
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version 2>' . syntastic#util#DevNull())
+    call self.log(self.getExec() . ' version = ', ver)
+
+    return syntastic#util#versionIsAtLeast(ver, [1, 6, 2])
 endfunction
 
 function! SyntaxCheckers_coffee_coffee_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/coffee/coffeelint.vim
+++ b/bundle/syntastic/syntax_checkers/coffee/coffeelint.vim
@@ -20,8 +20,9 @@ set cpo&vim
 
 function! SyntaxCheckers_coffee_coffeelint_GetLocList() dict
     if !exists('s:coffeelint_new')
-        let s:coffeelint_new = syntastic#util#versionIsAtLeast(syntastic#util#getVersion(
-            \ self.getExecEscaped() . ' --version'), [1, 4])
+        let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+        call self.log(self.getExec() . ' version =', ver)
+        let s:coffeelint_new = syntastic#util#versionIsAtLeast(ver, [1, 4])
     endif
     let makeprg = self.makeprgBuild({ 'args_after': (s:coffeelint_new ? '--reporter csv' : '--csv') })
 

--- a/bundle/syntastic/syntax_checkers/cpp/clang_check.vim
+++ b/bundle/syntastic/syntax_checkers/cpp/clang_check.vim
@@ -1,26 +1,25 @@
 "============================================================================
-"File:        avrgcc.vim
+"File:        clang_check.vim
 "Description: Syntax checking plugin for syntastic.vim
-"Maintainer:  Karel <karelishere at gmail dot com>
+"Maintainer:  Benjamin Bannier <bbannier at gmail dot com>
 "License:     This program is free software. It comes without any warranty,
 "             to the extent permitted by applicable law. You can redistribute
 "             it and/or modify it under the terms of the Do What The Fuck You
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
-"
 "============================================================================
 
-if exists('g:loaded_syntastic_arduino_avrgcc_checker')
-    finish
+if exists("g:loaded_syntastic_cpp_clang_check_checker")
+  finish
 endif
-let g:loaded_syntastic_arduino_avrgcc_checker = 1
+let g:loaded_syntastic_cpp_clang_check_checker = 1
 
 runtime! syntax_checkers/c/*.vim
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
-    \ 'filetype': 'c',
-    \ 'name': 'avrgcc',
-    \ 'exec': 'avr-gcc',
-    \ 'redirect': 'c/avrgcc'})
+    \ 'filetype': 'cpp',
+    \ 'name': 'clang_check',
+    \ 'exec': 'clang-check',
+    \ 'redirect': 'c/clang_check'})
 
 " vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/cpp/clang_tidy.vim
+++ b/bundle/syntastic/syntax_checkers/cpp/clang_tidy.vim
@@ -1,0 +1,25 @@
+"============================================================================
+"File:        clang_tidy.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Benjamin Bannier <bbannier at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists("g:loaded_syntastic_cpp_clang_tidy_checker")
+  finish
+endif
+let g:loaded_syntastic_cpp_clang_tidy_checker = 1
+
+runtime! syntax_checkers/c/*.vim
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'cpp',
+    \ 'name': 'clang_tidy',
+    \ 'exec': 'clang-tidy',
+    \ 'redirect': 'c/clang_tidy'})
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/cpp/cppcheck.vim
+++ b/bundle/syntastic/syntax_checkers/cpp/cppcheck.vim
@@ -8,13 +8,6 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "============================================================================
-"
-" The setting 'g:syntastic_cppcheck_config_file' allows you to define a file
-" that contains additional compiler arguments like include directories or
-" CFLAGS. The file is expected to contain one option per line. If none is
-" given the filename defaults to '.syntastic_cppcheck_config':
-"
-"   let g:syntastic_cppcheck_config_file = '.config'
 
 if exists("g:loaded_syntastic_cpp_cppcheck_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/cpp/cpplint.vim
+++ b/bundle/syntastic/syntax_checkers/cpp/cpplint.vim
@@ -9,18 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" For details about cpplint see:
-"    https://code.google.com/p/google-styleguide/
-"
-" Checker options:
-"
-" - g:syntastic_cpp_cpplint_thres (integer; default: 5)
-"   error threshold: policy violations with a severity above this
-"   value are highlighted as errors, the others are warnings
-"
-" - g:syntastic_cpp_cpplint_args (string; default: '--verbose=3')
-"   command line options to pass to cpplint
 
 if exists("g:loaded_syntastic_cpp_cpplint_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/cpp/gcc.vim
+++ b/bundle/syntastic/syntax_checkers/cpp/gcc.vim
@@ -26,7 +26,8 @@ function! SyntaxCheckers_cpp_gcc_IsAvailable() dict
     if !exists('g:syntastic_cpp_compiler')
         let g:syntastic_cpp_compiler = executable(self.getExec()) ? self.getExec() : 'clang++'
     endif
-    return executable(expand(g:syntastic_cpp_compiler))
+    call self.log('g:syntastic_cpp_compiler =', g:syntastic_cpp_compiler)
+    return executable(expand(g:syntastic_cpp_compiler, 1))
 endfunction
 
 function! SyntaxCheckers_cpp_gcc_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/cpp/oclint.vim
+++ b/bundle/syntastic/syntax_checkers/cpp/oclint.vim
@@ -8,13 +8,6 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "============================================================================
-"
-" The setting 'g:syntastic_oclint_config_file' allows you to define a file
-" that contains additional compiler arguments like include directories or
-" CFLAGS. The file is expected to contain one option per line. If none is
-" given the filename defaults to '.syntastic_oclint_config':
-"
-"   let g:syntastic_oclint_config_file = '.config'
 
 if exists("g:loaded_syntastic_cpp_oclint_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/cpp/pc_lint.vim
+++ b/bundle/syntastic/syntax_checkers/cpp/pc_lint.vim
@@ -1,0 +1,26 @@
+"============================================================================
+"File:        pc_lint.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Steve Bragg <steve at empresseffects dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists("g:loaded_syntastic_cpp_pc_lint_checker")
+    finish
+endif
+let g:loaded_syntastic_cpp_pc_lint_checker = 1
+
+runtime! syntax_checkers/c/*.vim
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'cpp',
+    \ 'name': 'pc_lint',
+    \ 'exec': 'lint-nt',
+    \ 'redirect': 'c/pc_lint'})
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/css/csslint.vim
+++ b/bundle/syntastic/syntax_checkers/css/csslint.vim
@@ -8,11 +8,6 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "============================================================================
-"
-" Specify additional options to csslint with this option. e.g. to disable
-" warnings:
-"
-"   let g:syntastic_csslint_options = '--warnings=none'
 
 if exists('g:loaded_syntastic_css_csslint_checker')
     finish

--- a/bundle/syntastic/syntax_checkers/css/phpcs.vim
+++ b/bundle/syntastic/syntax_checkers/css/phpcs.vim
@@ -9,10 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" See here for details of phpcs
-"    - phpcs (see http://pear.php.net/package/PHP_CodeSniffer)
-"
 
 if exists("g:loaded_syntastic_css_phpcs_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/css/prettycss.vim
+++ b/bundle/syntastic/syntax_checkers/css/prettycss.vim
@@ -9,16 +9,15 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" For details about PrettyCSS see:
-"
-"   - http://fidian.github.io/PrettyCSS/
-"   - https://github.com/fidian/PrettyCSS
 
 if exists("g:loaded_syntastic_css_prettycss_checker")
     finish
 endif
 let g:loaded_syntastic_css_prettycss_checker = 1
+
+if !exists('g:syntastic_css_prettycss_sort')
+    let g:syntastic_css_prettycss_sort = 1
+endif
 
 let s:save_cpo = &cpo
 set cpo&vim
@@ -48,8 +47,6 @@ function! SyntaxCheckers_css_prettycss_GetLocList() dict
     for e in loclist
         let e["text"] .= ')'
     endfor
-
-    call self.setWantSort(1)
 
     return loclist
 endfunction

--- a/bundle/syntastic/syntax_checkers/cuda/nvcc.vim
+++ b/bundle/syntastic/syntax_checkers/cuda/nvcc.vim
@@ -6,18 +6,6 @@
 "
 "============================================================================
 
-" in order to also check header files add this to your .vimrc:
-" (this creates an empty .syntastic_dummy.cu file in your source directory)
-"
-"   let g:syntastic_cuda_check_header = 1
-
-" By default, nvcc and thus syntastic, defaults to the most basic architecture.
-" This can produce false errors if the developer intends to compile for newer
-" hardware and use newer features, eg. double precision numbers. To pass a
-" specific target arch to nvcc, e.g. add the following to your .vimrc:
-"
-"   let g:syntastic_cuda_arch = "sm_20"
-
 if exists("g:loaded_syntastic_cuda_nvcc_checker")
     finish
 endif
@@ -53,7 +41,7 @@ function! SyntaxCheckers_cuda_nvcc_GetLocList() dict
         \ '%DMaking %*\a in %f,'.
         \ '%f|%l| %m'
 
-    if expand('%') =~? '\m\%(.h\|.hpp\|.cuh\)$'
+    if expand('%', 1) =~? '\m\%(.h\|.hpp\|.cuh\)$'
         if exists('g:syntastic_cuda_check_header')
             let makeprg =
                 \ 'echo > .syntastic_dummy.cu ; ' .

--- a/bundle/syntastic/syntax_checkers/d/dmd.vim
+++ b/bundle/syntastic/syntax_checkers/d/dmd.vim
@@ -31,7 +31,8 @@ function! SyntaxCheckers_d_dmd_IsAvailable() dict
     if !exists('g:syntastic_d_compiler')
         let g:syntastic_d_compiler = self.getExec()
     endif
-    return executable(expand(g:syntastic_d_compiler))
+    call self.log('g:syntastic_d_compiler =', g:syntastic_d_compiler)
+    return executable(expand(g:syntastic_d_compiler, 1))
 endfunction
 
 function! SyntaxCheckers_d_dmd_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/dart/dartanalyzer.vim
+++ b/bundle/syntastic/syntax_checkers/dart/dartanalyzer.vim
@@ -53,7 +53,7 @@ function! SyntaxCheckers_dart_dartanalyzer_GetLocList() dict
     let loclist = SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'returns': [0, 1, 2] })
+        \ 'returns': [0, 1, 2, 3] })
 
     for e in loclist
         let e['text'] = substitute(e['text'], '\m\\\([\\|]\)', '\1', 'g')

--- a/bundle/syntastic/syntax_checkers/docbk/igor.vim
+++ b/bundle/syntastic/syntax_checkers/docbk/igor.vim
@@ -1,0 +1,55 @@
+"============================================================================
+"File:        igor.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_docbk_igor_checker')
+    finish
+endif
+let g:loaded_syntastic_docbk_igor_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_docbk_igor_GetLocList() dict
+    let makeprg = self.makeprgBuild({})
+
+    let errorformat = '%f:%l:%m'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': { 'type': 'W' },
+        \ 'subtype': 'Style',
+        \ 'returns': [0] })
+
+    let buf = bufnr('')
+    for e in loclist
+        " XXX: igor strips directories from filenames
+        let e['bufnr'] = buf
+
+        let e['hl'] = '\V' . escape( substitute(e['text'], '\m[^:]*:', '', ''), '\' )
+        let e['hl'] = substitute(e['hl'], '\V[', '\\zs', 'g')
+        let e['hl'] = substitute(e['hl'], '\V]', '\\ze', 'g')
+
+        " let e['text'] = substitute(e['text'], '\m:.*$', '', '')
+    endfor
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'docbk',
+    \ 'name': 'igor'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/elixir/elixir.vim
+++ b/bundle/syntastic/syntax_checkers/elixir/elixir.vim
@@ -20,6 +20,9 @@ set cpo&vim
 
 " TODO: we should probably split this into separate checkers
 function! SyntaxCheckers_elixir_elixir_IsAvailable() dict
+    call self.log(
+        \ 'executable("elixir") = ' . executable('elixir') . ', ' .
+        \ 'executable("mix") = ' . executable('mix'))
     return executable('elixir') && executable('mix')
 endfunction
 
@@ -32,7 +35,7 @@ function! SyntaxCheckers_elixir_elixir_GetLocList() dict
 
     let make_options = {}
     let compile_command = 'elixir'
-    let mix_file = syntastic#util#findInParent('mix.exs', expand('%:p:h'))
+    let mix_file = syntastic#util#findInParent('mix.exs', expand('%:p:h', 1))
 
     if filereadable(mix_file)
         let compile_command = 'mix compile'

--- a/bundle/syntastic/syntax_checkers/erlang/erlang_check_file.erl
+++ b/bundle/syntastic/syntax_checkers/erlang/erlang_check_file.erl
@@ -32,7 +32,7 @@ main([FileName, "-rebar", Path, LibDirs]) ->
     %io:format("~p~n", [LibDirs1]),
     compile(FileName, LibDirs1);
 
-main([FileName, LibDirs]) ->
+main([FileName | LibDirs]) ->
     compile(FileName, LibDirs).
 
 compile(FileName, LibDirs) ->
@@ -45,7 +45,12 @@ compile(FileName, LibDirs) ->
                   warn_export_vars,
                   strong_validation,
                   report] ++
-                 [{i, filename:join(Root, I)} || I <- LibDirs]).
+                 [{i, filename:join(Root, I)} || I <- LibDirs] ++
+                 case lists:member("deps/pmod_transform/include", LibDirs) of
+                     true -> [{parse_transform, pmod_pt}];
+                     _    -> []
+                 end
+                ).
 
 get_root(Dir) ->
     Path = filename:split(filename:absname(Dir)),

--- a/bundle/syntastic/syntax_checkers/erlang/escript.vim
+++ b/bundle/syntastic/syntax_checkers/erlang/escript.vim
@@ -19,13 +19,13 @@ if !exists('g:syntastic_erlc_include_path')
     let g:syntastic_erlc_include_path = ''
 endif
 
-let s:check_file = syntastic#util#shescape(expand('<sfile>:p:h') . syntastic#util#Slash() . 'erlang_check_file.erl')
+let s:check_file = syntastic#util#shescape(expand('<sfile>:p:h', 1) . syntastic#util#Slash() . 'erlang_check_file.erl')
 
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_erlang_escript_GetLocList() dict
-    if expand('%:e') ==# 'hrl'
+    if expand('%:e', 1) ==# 'hrl'
         return []
     endif
 

--- a/bundle/syntastic/syntax_checkers/eruby/ruby.vim
+++ b/bundle/syntastic/syntax_checkers/eruby/ruby.vim
@@ -21,12 +21,13 @@ set cpo&vim
 function! SyntaxCheckers_eruby_ruby_IsAvailable() dict
     if !exists('g:syntastic_eruby_ruby_exec') && exists('g:syntastic_ruby_exec')
         let g:syntastic_eruby_ruby_exec = g:syntastic_ruby_exec
+        call self.log('g:syntastic_eruby_ruby_exec =', g:syntastic_eruby_ruby_exec)
     endif
     return executable(self.getExec())
 endfunction
 
 function! SyntaxCheckers_eruby_ruby_GetLocList() dict
-    let fname = "'" . escape(expand('%'), "\\'") . "'"
+    let fname = "'" . escape(expand('%', 1), "\\'") . "'"
 
     " TODO: encodings became useful in ruby 1.9 :)
     if syntastic#util#versionIsAtLeast(syntastic#util#getVersion(self.getExecEscaped(). ' --version'), [1, 9])
@@ -42,9 +43,16 @@ function! SyntaxCheckers_eruby_ruby_GetLocList() dict
         \ syntastic#util#shescape('puts ERB.new(File.read(' .
         \     fname . encoding_spec .
         \     ').gsub(''<%='',''<%''), nil, ''-'').src') .
-        \ ' | ' . self.getExecEscaped() . ' -c'
+        \ ' | ' . self.getExecEscaped() . ' -w -c'
 
-    let errorformat =
+    let errorformat = '%-G%\m%.%#warning: %\%%(possibly %\)%\?useless use of a literal in void context,'
+
+    " filter out lines starting with ...
+    " long lines are truncated and wrapped in ... %p then returns the wrong
+    " column offset
+    let errorformat .= '%-G%\%.%\%.%\%.%.%#,'
+
+    let errorformat .=
         \ '%-GSyntax OK,'.
         \ '%E-:%l: syntax error\, %m,%Z%p^,'.
         \ '%W-:%l: warning: %m,'.

--- a/bundle/syntastic/syntax_checkers/fortran/gfortran.vim
+++ b/bundle/syntastic/syntax_checkers/fortran/gfortran.vim
@@ -26,7 +26,8 @@ function! SyntaxCheckers_fortran_gfortran_IsAvailable() dict
     if !exists('g:syntastic_fortran_compiler')
         let g:syntastic_fortran_compiler = self.getExec()
     endif
-    return executable(expand(g:syntastic_fortran_compiler))
+    call self.log('g:syntastic_fortran_compiler = ', g:syntastic_fortran_compiler)
+    return executable(expand(g:syntastic_fortran_compiler, 1))
 endfunction
 
 function! SyntaxCheckers_fortran_gfortran_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/glsl/cgc.vim
+++ b/bundle/syntastic/syntax_checkers/glsl/cgc.vim
@@ -61,7 +61,7 @@ function! s:GetProfile()
         let profile = matchstr(getline(line), magic . '\zs.*')
     else
         let extensions = exists('g:syntastic_glsl_extensions') ? g:syntastic_glsl_extensions : s:glsl_extensions
-        let profile = get(extensions, tolower(expand('%:e')), 'gpu_vert')
+        let profile = get(extensions, tolower(expand('%:e', 1)), 'gpu_vert')
     endif
 
     return profile

--- a/bundle/syntastic/syntax_checkers/go/go.vim
+++ b/bundle/syntastic/syntax_checkers/go/go.vim
@@ -8,10 +8,11 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
+"============================================================================
+"
 " This syntax checker does not reformat your source code.
 " Use a BufWritePre autocommand to that end:
 "   autocmd FileType go autocmd BufWritePre <buffer> Fmt
-"============================================================================
 
 if exists("g:loaded_syntastic_go_go_checker")
     finish
@@ -22,7 +23,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_go_go_IsAvailable() dict
-    return executable('go') && executable('gofmt')
+    return executable(self.getExec()) && executable('gofmt')
 endfunction
 
 function! SyntaxCheckers_go_go_GetLocList() dict
@@ -48,11 +49,11 @@ function! SyntaxCheckers_go_go_GetLocList() dict
 
     " Test files, i.e. files with a name ending in `_test.go`, are not
     " compiled by `go build`, therefore `go test` must be called for those.
-    if match(expand('%'), '\m_test\.go$') == -1
-        let makeprg = 'go build ' . syntastic#c#NullOutput()
+    if match(expand('%', 1), '\m_test\.go$') == -1
+        let makeprg = self.getExec() . ' build ' . syntastic#c#NullOutput()
         let cleanup = 0
     else
-        let makeprg = 'go test -c ' . syntastic#c#NullOutput()
+        let makeprg = self.getExec() . ' test -c ' . syntastic#c#NullOutput()
         let cleanup = 1
     endif
 
@@ -71,11 +72,11 @@ function! SyntaxCheckers_go_go_GetLocList() dict
     let errors = SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'cwd': expand('%:p:h'),
+        \ 'cwd': expand('%:p:h', 1),
         \ 'defaults': {'type': 'e'} })
 
     if cleanup
-        call delete(expand('%:p:h') . syntastic#util#Slash() . expand('%:p:h:t') . '.test')
+        call delete(expand('%:p:h', 1) . syntastic#util#Slash() . expand('%:p:h:t', 1) . '.test')
     endif
 
     return errors

--- a/bundle/syntastic/syntax_checkers/go/gofmt.vim
+++ b/bundle/syntastic/syntax_checkers/go/gofmt.vim
@@ -8,10 +8,11 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
+"============================================================================
+"
 " This syntax checker does not reformat your source code.
 " Use a BufWritePre autocommand to that end:
 "   autocmd FileType go autocmd BufWritePre <buffer> Fmt
-"============================================================================
 
 if exists("g:loaded_syntastic_go_gofmt_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/go/golint.vim
+++ b/bundle/syntastic/syntax_checkers/go/golint.vim
@@ -21,11 +21,14 @@ set cpo&vim
 function! SyntaxCheckers_go_golint_GetLocList() dict
     let makeprg = self.makeprgBuild({})
 
-    let errorformat = '%f:%l:%c: %m,%-G%.%#'
+    let errorformat =
+        \ '%f:%l:%c: %m,' .
+        \ '%-G%.%#'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
+        \ 'defaults': {'type': 'w'},
         \ 'subtype': 'Style' })
 endfunction
 

--- a/bundle/syntastic/syntax_checkers/go/gotype.vim
+++ b/bundle/syntastic/syntax_checkers/go/gotype.vim
@@ -29,13 +29,11 @@ function! SyntaxCheckers_go_gotype_GetLocList() dict
     " the package for the same reasons specified in go.vim ("figuring out
     " the import path is fickle").
 
-    let errors = SyntasticMake({
+    return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'cwd': expand('%:p:h'),
+        \ 'cwd': expand('%:p:h', 1),
         \ 'defaults': {'type': 'e'} })
-
-    return errors
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/go/govet.vim
+++ b/bundle/syntastic/syntax_checkers/go/govet.vim
@@ -19,29 +19,32 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_go_govet_IsAvailable() dict
-    return executable('go')
+    return executable(self.getExec())
 endfunction
 
 function! SyntaxCheckers_go_govet_GetLocList() dict
-    let makeprg = 'go vet'
-    let errorformat = '%Evet: %.%\+: %f:%l:%c: %m,%W%f:%l: %m,%-G%.%#'
+    let makeprg = self.getExec() . ' vet'
+
+    let errorformat =
+        \ '%Evet: %.%\+: %f:%l:%c: %m,' .
+        \ '%W%f:%l: %m,' .
+        \ '%-G%.%#'
 
     " The go compiler needs to either be run with an import path as an
     " argument or directly from the package directory. Since figuring out
     " the proper import path is fickle, just cwd to the package.
 
-    let errors = SyntasticMake({
+    return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'cwd': expand('%:p:h'),
+        \ 'cwd': expand('%:p:h', 1),
         \ 'defaults': {'type': 'w'} })
-
-    return errors
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
     \ 'filetype': 'go',
-    \ 'name': 'govet'})
+    \ 'name': 'govet',
+    \ 'exec': 'go' })
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/bundle/syntastic/syntax_checkers/handlebars/handlebars.vim
+++ b/bundle/syntastic/syntax_checkers/handlebars/handlebars.vim
@@ -29,6 +29,7 @@ function! SyntaxCheckers_handlebars_handlebars_GetLocList() dict
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
+        \ 'postprocess': ['guards'],
         \ 'defaults': {'bufnr': bufnr("")} })
 endfunction
 

--- a/bundle/syntastic/syntax_checkers/haskell/ghc-mod.vim
+++ b/bundle/syntastic/syntax_checkers/haskell/ghc-mod.vim
@@ -21,10 +21,33 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_haskell_ghc_mod_IsAvailable() dict
-    " We need either a Vim version that can handle NULs in system() output,
-    " or a ghc-mod version that has the --boundary option.
-    let exe = self.getExec()
-    let s:ghc_mod_new = executable(exe) ? s:GhcModNew(exe) : -1
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    " ghc-mod 5.0.0 and later needs the "version" command to print the
+    " version.  But the "version" command appeared in 4.1.0.  Thus, we need to
+    " know the version in order to know how to find out the version. :)
+
+    " Try "ghc-mod version".
+    let ver = filter(split(system(self.getExecEscaped() . ' version'), '\n'), 'v:val =~# ''\m\sversion''')
+    if !len(ver)
+        " That didn't work.  Try "ghc-mod" alone.
+        let ver = filter(split(system(self.getExecEscaped()), '\n'), 'v:val =~# ''\m\sversion''')
+    endif
+
+    if len(ver)
+        " Encouraged by the great success in finding out the version, now we
+        " need either a Vim that can handle NULs in system() output, or a
+        " ghc-mod that has the "--boundary" option.
+        let parsed_ver = syntastic#util#parseVersion(ver[0])
+        call self.log(self.getExec() . ' version =', parsed_ver)
+        let s:ghc_mod_new = syntastic#util#versionIsAtLeast(parsed_ver, [2, 1, 2])
+    else
+        call syntastic#log#error("checker haskell/ghc_mod: can't parse version string (abnormal termination?)")
+        let s:ghc_mod_new = -1
+    endif
+
     return (s:ghc_mod_new >= 0) && (v:version >= 704 || s:ghc_mod_new)
 endfunction
 
@@ -47,18 +70,6 @@ function! SyntaxCheckers_haskell_ghc_mod_GetLocList() dict
         \ 'errorformat': errorformat,
         \ 'postprocess': ['compressWhitespace'],
         \ 'returns': [0] })
-endfunction
-
-function! s:GhcModNew(exe)
-    let exe = syntastic#util#shescape(a:exe)
-    try
-        let ghc_mod_version = filter(split(system(exe), '\n'), 'v:val =~# ''\m^ghc-mod version''')[0]
-        let ret = syntastic#util#versionIsAtLeast(syntastic#util#parseVersion(ghc_mod_version), [2, 1, 2])
-    catch /\m^Vim\%((\a\+)\)\=:E684/
-        call syntastic#log#error("checker haskell/ghc_mod: can't parse version string (abnormal termination?)")
-        let ret = -1
-    endtry
-    return ret
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/haskell/scan.vim
+++ b/bundle/syntastic/syntax_checkers/haskell/scan.vim
@@ -15,6 +15,10 @@ if exists('g:loaded_syntastic_haskell_scan_checker')
 endif
 let g:loaded_syntastic_haskell_scan_checker = 1
 
+if !exists('g:syntastic_haskell_scan_sort')
+    let g:syntastic_haskell_scan_sort = 1
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -23,14 +27,10 @@ function! SyntaxCheckers_haskell_scan_GetLocList() dict
 
     let errorformat = '%f:%l:%v: %m'
 
-    let loclist = SyntasticMake({
+    return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'subtype': 'Style' })
-
-    call self.setWantSort(1)
-
-    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/haxe/haxe.vim
+++ b/bundle/syntastic/syntax_checkers/haxe/haxe.vim
@@ -24,9 +24,11 @@ function! SyntaxCheckers_haxe_haxe_GetLocList() dict
     elseif exists('g:vaxe_hxml')
         let hxml = g:vaxe_hxml
     else
-        let hxml = syntastic#util#findInParent('*.hxml', expand('%:p:h'))
+        let hxml = syntastic#util#findInParent('*.hxml', expand('%:p:h', 1))
     endif
     let hxml = fnamemodify(hxml, ':p')
+
+    call self.log('hxml =', hxml)
 
     if hxml != ''
         let makeprg = self.makeprgBuild({

--- a/bundle/syntastic/syntax_checkers/html/jshint.vim
+++ b/bundle/syntastic/syntax_checkers/html/jshint.vim
@@ -19,8 +19,14 @@ set cpo&vim
 
 function! SyntaxCheckers_html_jshint_IsAvailable() dict
     call syntastic#log#deprecationWarn('jshint_exec', 'html_jshint_exec')
-    return executable(self.getExec()) &&
-        \ syntastic#util#versionIsAtLeast(syntastic#util#getVersion(self.getExecEscaped() . ' --version'), [2,4])
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+    call self.log(self.getExec() . ' version =', ver)
+
+    return syntastic#util#versionIsAtLeast(ver, [2, 4])
 endfunction
 
 function! SyntaxCheckers_html_jshint_GetLocList() dict
@@ -30,8 +36,6 @@ function! SyntaxCheckers_html_jshint_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'args_after': '--verbose --extract always' })
 
     let errorformat = '%A%f: line %l\, col %v\, %m \(%t%*\d\)'
-
-    call self.setWantSort(1)
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/bundle/syntastic/syntax_checkers/html/tidy.vim
+++ b/bundle/syntastic/syntax_checkers/html/tidy.vim
@@ -17,17 +17,6 @@
 "
 " HTML Tidy for HTML5 can be used without changes by this checker, just install
 " it and point g:syntastic_html_tidy_exec to the executable.
-"
-" Checker options:
-"
-" - g:syntastic_html_tidy_ignore_errors (list; default: [])
-"   list of errors to ignore
-" - g:syntastic_html_tidy_blocklevel_tags (list; default: [])
-"   list of additional blocklevel tags, to be added to "--new-blocklevel-tags"
-" - g:syntastic_html_tidy_inline_tags (list; default: [])
-"   list of additional inline tags, to be added to "--new-inline-tags"
-" - g:syntastic_html_tidy_empty_tags (list; default: [])
-"   list of additional empty tags, to be added to "--new-empty-tags"
 
 if exists("g:loaded_syntastic_html_tidy_checker")
     finish
@@ -55,7 +44,7 @@ set cpo&vim
 
 " TODO: join this with xhtml.vim for DRY's sake?
 function! s:TidyEncOptByFenc()
-    let tidy_opts = {
+    let TIDY_OPTS = {
             \ 'utf-8':        '-utf8',
             \ 'ascii':        '-ascii',
             \ 'latin1':       '-latin1',
@@ -69,10 +58,10 @@ function! s:TidyEncOptByFenc()
             \ 'sjis':         '-shiftjis',
             \ 'cp850':        '-ibm858',
         \ }
-    return get(tidy_opts, &fileencoding, '-utf8')
+    return get(TIDY_OPTS, &fileencoding, '-utf8')
 endfunction
 
-let s:ignore_errors = [
+let s:IGNORE_ERRORS = [
         \ "<table> lacks \"summary\" attribute",
         \ "not approved by W3C",
         \ "<input> proprietary attribute \"placeholder\"",
@@ -123,9 +112,9 @@ let s:ignore_errors = [
         \ "proprietary attribute \"aria-valuenow\"",
         \ "proprietary attribute \"aria-valuetext\""
     \ ]
-lockvar! s:ignore_errors
+lockvar! s:IGNORE_ERRORS
 
-let s:blocklevel_tags = [
+let s:BLOCKLEVEL_TAGS = [
         \ "main",
         \ "section",
         \ "article",
@@ -136,9 +125,9 @@ let s:blocklevel_tags = [
         \ "figure",
         \ "figcaption"
     \ ]
-lockvar! s:blocklevel_tags
+lockvar! s:BLOCKLEVEL_TAGS
 
-let s:inline_tags = [
+let s:INLINE_TAGS = [
         \ "video",
         \ "audio",
         \ "source",
@@ -155,17 +144,17 @@ let s:inline_tags = [
         \ "details",
         \ "datalist"
     \ ]
-lockvar! s:inline_tags
+lockvar! s:INLINE_TAGS
 
-let s:empty_tags = [
+let s:EMPTY_TAGS = [
         \ "wbr",
         \ "keygen"
     \ ]
-lockvar! s:empty_tags
+lockvar! s:EMPTY_TAGS
 
 function! s:IgnoreError(text)
-    for i in s:ignore_errors + g:syntastic_html_tidy_ignore_errors
-        if stridx(a:text, i) != -1
+    for item in s:IGNORE_ERRORS + g:syntastic_html_tidy_ignore_errors
+        if stridx(a:text, item) != -1
             return 1
         endif
     endfor
@@ -173,7 +162,7 @@ function! s:IgnoreError(text)
 endfunction
 
 function! s:NewTags(name)
-    return syntastic#util#shescape(join( s:{a:name} + g:syntastic_html_tidy_{a:name}, ',' ))
+    return syntastic#util#shescape(join( s:{toupper(a:name)} + g:syntastic_html_tidy_{a:name}, ',' ))
 endfunction
 
 function! s:Args()

--- a/bundle/syntastic/syntax_checkers/html/validator.vim
+++ b/bundle/syntastic/syntax_checkers/html/validator.vim
@@ -9,24 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" For detail;s about validator see: http://about.validator.nu/
-"
-" Checker options:
-"
-" - g:syntastic_html_validator_api (string; default: 'http://validator.nu/')
-"   URL of the service to use for checking; leave it to the default to run the
-"   checks against http://validator.nu/, or set it to 'http://localhost:8888/'
-"   if you're running a local service as per http://about.validator.nu/#src
-"
-" - g:syntastic_html_validator_parser (string; default: empty)
-"   parser to use; legal values are: xml, xmldtd, html, html5, html4, html4tr;
-"   set it to 'html5' to check HTML5 files;  see the wiki for reference:
-"   http://wiki.whatwg.org/wiki/Validator.nu_Common_Input_Parameters#parser
-"
-" - g:syntastic_html_validator_nsfilter (string; default: empty)
-"   sets the nsfilter for the parser; see the wiki for details:
-"   http://wiki.whatwg.org/wiki/Validator.nu_Common_Input_Parameters#nsfilter
 
 if exists("g:loaded_syntastic_html_validator_checker")
     finish
@@ -50,7 +32,7 @@ set cpo&vim
 
 function! SyntaxCheckers_html_validator_GetLocList() dict
     let fname = syntastic#util#shexpand('%')
-    let makeprg = self.getExecEscaped() . ' -s --compressed -F out=gnu -F asciiquotes=yes' .
+    let makeprg = self.getExecEscaped() . ' -q -s --compressed -F out=gnu -F asciiquotes=yes' .
         \ (g:syntastic_html_validator_parser != '' ? ' -F parser=' . g:syntastic_html_validator_parser : '') .
         \ (g:syntastic_html_validator_nsfilter != '' ? ' -F nsfilter=' . g:syntastic_html_validator_nsfilter : '') .
         \ ' -F doc=@' . fname . '\;type=text/html\;filename=' . fname . ' ' . g:syntastic_html_validator_api

--- a/bundle/syntastic/syntax_checkers/html/w3.vim
+++ b/bundle/syntastic/syntax_checkers/html/w3.vim
@@ -9,13 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" Checker option:
-"
-" - g:syntastic_html_w3_api (string; default: 'http://validator.w3.org/check')
-"   URL of the service to use for checking; leave it to the default to run the
-"   checks against http://validator.w3.org/, or set it to
-"   'http://localhost/w3c-validator/check' if you're running a local service
 
 if exists("g:loaded_syntastic_html_w3_checker")
     finish
@@ -30,7 +23,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_html_w3_GetLocList() dict
-    let makeprg = self.getExecEscaped() . ' -s -F output=json ' .
+    let makeprg = self.getExecEscaped() . ' -q -s -F output=json ' .
         \ '-F uploaded_file=@' . syntastic#util#shexpand('%:p') . '\;type=text/html ' .
         \ g:syntastic_html_w3_api
 

--- a/bundle/syntastic/syntax_checkers/java/checkstyle.vim
+++ b/bundle/syntastic/syntax_checkers/java/checkstyle.vim
@@ -27,19 +27,34 @@ endif
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! SyntaxCheckers_java_checkstyle_IsAvailable() dict
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    let classpath = expand(g:syntastic_java_checkstyle_classpath, 1)
+    let conf_file = expand(g:syntastic_java_checkstyle_conf_file, 1)
+    call self.log(
+        \ 'filereadable(' . string(classpath) . ') = ' . filereadable(classpath) . ', ' .
+        \ 'filereadable(' . string(conf_file) . ') = ' . filereadable(conf_file))
+
+    return filereadable(classpath) && filereadable(conf_file)
+endfunction
+
 function! SyntaxCheckers_java_checkstyle_GetLocList() dict
 
-    let fname = syntastic#util#shescape( expand('%:p:h') . '/' . expand('%:t') )
+    let fname = syntastic#util#shescape( expand('%:p:h', 1) . syntastic#util#Slash() . expand('%:t', 1) )
 
     if has('win32unix')
         let fname = substitute(system('cygpath -m ' . fname), '\m\%x00', '', 'g')
     endif
 
     let makeprg = self.makeprgBuild({
-        \ 'args_after': '-cp ' . g:syntastic_java_checkstyle_classpath .
-        \       ' com.puppycrawl.tools.checkstyle.Main -c ' .
-        \       syntastic#util#shexpand(g:syntastic_java_checkstyle_conf_file) .
-        \       ' -f xml',
+        \ 'args_after': [
+        \       '-cp', expand(g:syntastic_java_checkstyle_classpath, 1),
+        \       'com.puppycrawl.tools.checkstyle.Main',
+        \       '-c', expand(g:syntastic_java_checkstyle_conf_file, 1),
+        \       '-f', 'xml'],
         \ 'fname': fname })
 
     let errorformat = '%f:%t:%l:%c:%m'

--- a/bundle/syntastic/syntax_checkers/java/javac.vim
+++ b/bundle/syntastic/syntax_checkers/java/javac.vim
@@ -51,15 +51,7 @@ function! s:CygwinPath(path)
 endfunction
 
 if !exists('g:syntastic_java_javac_temp_dir')
-    if has('win32') || has('win64')
-        let g:syntastic_java_javac_temp_dir = $TEMP . syntastic#util#Slash() . 'vim-syntastic-javac'
-    elseif has('win32unix')
-        let g:syntastic_java_javac_temp_dir = s:CygwinPath('/tmp/vim-syntastic-javac')
-    elseif $TMPDIR != ''
-        let g:syntastic_java_javac_temp_dir = $TMPDIR . '/vim-syntastic-javac'
-    else
-        let g:syntastic_java_javac_temp_dir = '/tmp/vim-syntastic-javac'
-    endif
+    let g:syntastic_java_javac_temp_dir = syntastic#util#tmpdir()
 endif
 
 if !exists('g:syntastic_java_javac_autoload_maven_classpath')
@@ -90,18 +82,6 @@ function! s:RemoveCarriageReturn(line)
     return substitute(a:line, "\r", '', 'g')
 endfunction
 
-" recursively remove directory and all it's sub-directories
-function! s:RemoveDir(dir)
-    if isdirectory(a:dir)
-        for f in split(globpath(a:dir, '*'), "\n")
-            call s:RemoveDir(f)
-        endfor
-        silent! call system('rmdir ' . syntastic#util#shescape(a:dir))
-    else
-        silent! call delete(a:dir)
-    endif
-endfunction
-
 function! s:ClassSep()
     return (syntastic#util#isRunningWindows() || has('win32unix')) ? ';' : ':'
 endfunction
@@ -118,8 +98,8 @@ function! s:SplitClasspath(classpath)
 endfunction
 
 function! s:LoadConfigFile()
-    if filereadable(expand(g:syntastic_java_javac_config_file))
-        exe 'source ' . fnameescape(expand(g:syntastic_java_javac_config_file))
+    if filereadable(expand(g:syntastic_java_javac_config_file, 1))
+        exe 'source ' . fnameescape(expand(g:syntastic_java_javac_config_file, 1))
     endif
 endfunction
 
@@ -132,9 +112,9 @@ function! s:SaveClasspath()
     endfor
     " save classpath to config file
     if g:syntastic_java_javac_config_file_enabled
-        if filereadable(expand(g:syntastic_java_javac_config_file))
+        if filereadable(expand(g:syntastic_java_javac_config_file, 1))
             " load lines from config file
-            let lines = readfile(expand(g:syntastic_java_javac_config_file))
+            let lines = readfile(expand(g:syntastic_java_javac_config_file, 1))
             " strip g:syntastic_java_javac_classpath options from config file lines
             let i = 0
             while i < len(lines)
@@ -150,7 +130,7 @@ function! s:SaveClasspath()
         " add new g:syntastic_java_javac_classpath option to config
         call add(lines, 'let g:syntastic_java_javac_classpath = ' . string(path))
         " save config file lines
-        call writefile(lines, expand(g:syntastic_java_javac_config_file))
+        call writefile(lines, expand(g:syntastic_java_javac_config_file, 1))
     endif
     " set new classpath
     let g:syntastic_java_javac_classpath = path
@@ -187,7 +167,7 @@ function! s:SaveConfig()
     let lines = getline(1, line('$'))
     if g:syntastic_java_javac_config_file_enabled
         " save config file lines
-        call writefile(lines, expand(g:syntastic_java_javac_config_file))
+        call writefile(lines, expand(g:syntastic_java_javac_config_file, 1))
     endif
     let &modified = 0
 endfunction
@@ -197,8 +177,8 @@ function! s:EditConfig()
     let winnr = bufwinnr('^' . command . '$')
     if winnr < 0
         let lines = []
-        if filereadable(expand(g:syntastic_java_javac_config_file))
-            let lines = readfile(expand(g:syntastic_java_javac_config_file))
+        if filereadable(expand(g:syntastic_java_javac_config_file, 1))
+            let lines = readfile(expand(g:syntastic_java_javac_config_file, 1))
         endif
         execute (len(lines) + 5) . 'sp ' . fnameescape(command)
 
@@ -302,8 +282,8 @@ function! s:GetMavenClasspath()
 endfunction
 
 function! SyntaxCheckers_java_javac_IsAvailable() dict
-    let s:has_maven = executable(expand(g:syntastic_java_maven_executable))
-    return executable(expand(g:syntastic_java_javac_executable))
+    let s:has_maven = executable(expand(g:syntastic_java_maven_executable, 1))
+    return executable(expand(g:syntastic_java_javac_executable, 1))
 endfunction
 
 function! s:MavenOutputDirectory()
@@ -314,13 +294,13 @@ function! s:MavenOutputDirectory()
         if has_key(mvn_properties, 'project.properties.build.dir')
             let output_dir = mvn_properties['project.properties.build.dir']
         endif
-        if stridx(expand( '%:p:h' ), 'src.main.java') >= 0
+        if stridx(expand('%:p:h', 1), 'src.main.java') >= 0
             let output_dir .= '/target/classes'
             if has_key(mvn_properties, 'project.build.outputDirectory')
                 let output_dir = mvn_properties['project.build.outputDirectory']
             endif
         endif
-        if stridx(expand( '%:p:h' ), 'src.test.java') >= 0
+        if stridx(expand('%:p:h', 1), 'src.test.java') >= 0
             let output_dir .= '/target/test-classes'
             if has_key(mvn_properties, 'project.build.testOutputDirectory')
                 let output_dir = mvn_properties['project.build.testOutputDirectory']
@@ -355,9 +335,9 @@ function! SyntaxCheckers_java_javac_GetLocList() dict
     for path in split(g:syntastic_java_javac_classpath, s:ClassSep())
         if path != ''
             try
-                let ps = glob(path, 0, 1)
+                let ps = glob(path, 1, 1)
             catch
-                let ps = split(glob(path, 0), "\n")
+                let ps = split(glob(path, 1), "\n")
             endtry
             if type(ps) == type([])
                 for p in ps
@@ -391,7 +371,7 @@ function! SyntaxCheckers_java_javac_GetLocList() dict
         let javac_opts .= ' -cp ' . syntastic#util#shexpand(javac_classpath)
     endif
 
-    let fname = expand('%:p:h') . syntastic#util#Slash() . expand ('%:t')
+    let fname = expand('%:p:h', 1) . syntastic#util#Slash() . expand ('%:t', 1)
 
     if has('win32unix')
         let fname = s:CygwinPath(fname)
@@ -419,7 +399,7 @@ function! SyntaxCheckers_java_javac_GetLocList() dict
         \ 'postprocess': ['cygwinRemoveCR'] })
 
     if g:syntastic_java_javac_delete_output
-        call s:RemoveDir(output_dir)
+        call syntastic#util#rmrf(output_dir)
     endif
     return errors
 

--- a/bundle/syntastic/syntax_checkers/javascript/closurecompiler.vim
+++ b/bundle/syntastic/syntax_checkers/javascript/closurecompiler.vim
@@ -20,31 +20,43 @@ set cpo&vim
 function! SyntaxCheckers_javascript_closurecompiler_IsAvailable() dict
     call syntastic#log#deprecationWarn('javascript_closure_compiler_path', 'javascript_closurecompiler_path')
 
-    return
-        \ executable("java") &&
-        \ exists("g:syntastic_javascript_closurecompiler_path") &&
-        \ filereadable(g:syntastic_javascript_closurecompiler_path)
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    let s:has_script = exists('g:syntastic_javascript_closurecompiler_script')
+    if s:has_script
+        return 1
+    endif
+
+    let cp = get(g:, 'syntastic_javascript_closurecompiler_path', '')
+    call self.log('g:syntastic_javascript_closurecompiler_path =', cp)
+
+    let jar = expand(cp, 1)
+    call self.log('filereadable(' . string(jar) . ') = ' . filereadable(jar))
+
+    return filereadable(jar)
 endfunction
 
 function! SyntaxCheckers_javascript_closurecompiler_GetLocList() dict
     call syntastic#log#deprecationWarn('javascript_closure_compiler_options', 'javascript_closurecompiler_args')
     call syntastic#log#deprecationWarn('javascript_closure_compiler_file_list', 'javascript_closurecompiler_file_list')
 
-    if exists("g:syntastic_javascript_closurecompiler_file_list")
-        let file_list = join(readfile(g:syntastic_javascript_closurecompiler_file_list))
+    let flist = expand(get(g:, 'syntastic_javascript_closurecompiler_file_list', ''), 1)
+    if filereadable(flist)
+        let file_list = map( readfile(flist), 'expand(v:var, 1)' )
     else
-        let file_list = syntastic#util#shexpand('%')
+        let file_list = [expand('%', 1)]
     endif
 
     let makeprg = self.makeprgBuild({
-        \ 'exe_after': '-jar ' . g:syntastic_javascript_closurecompiler_path,
-        \ 'args_after': '--js' ,
+        \ 'exe_after': (s:has_script ? [] : ['-jar', expand(g:syntastic_javascript_closurecompiler_path, 1)]),
+        \ 'args_after': '--js',
         \ 'fname': file_list })
 
     let errorformat =
         \ '%-GOK,'.
         \ '%E%f:%l: ERROR - %m,'.
-        \ '%Z%p^,'.
         \ '%W%f:%l: WARNING - %m,'.
         \ '%Z%p^'
 
@@ -56,7 +68,7 @@ endfunction
 call g:SyntasticRegistry.CreateAndRegisterChecker({
     \ 'filetype': 'javascript',
     \ 'name': 'closurecompiler',
-    \ 'exec': 'java'})
+    \ 'exec': get(g:, 'syntastic_javascript_closurecompiler_script', 'java')})
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/bundle/syntastic/syntax_checkers/javascript/eslint.vim
+++ b/bundle/syntastic/syntax_checkers/javascript/eslint.vim
@@ -14,13 +14,22 @@ if exists('g:loaded_syntastic_javascript_eslint_checker')
 endif
 let g:loaded_syntastic_javascript_eslint_checker = 1
 
+if !exists('g:syntastic_javascript_eslint_sort')
+    let g:syntastic_javascript_eslint_sort = 1
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_javascript_eslint_IsAvailable() dict
-    return
-        \ executable(self.getExec()) &&
-        \ syntastic#util#versionIsAtLeast(syntastic#util#getVersion(self.getExecEscaped() . ' --version'), [0, 1])
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+    call self.log(self.getExec() . ' version =', ver)
+
+    return syntastic#util#versionIsAtLeast(ver, [0, 1])
 endfunction
 
 function! SyntaxCheckers_javascript_eslint_GetLocList() dict
@@ -35,13 +44,12 @@ function! SyntaxCheckers_javascript_eslint_GetLocList() dict
 
     let loclist = SyntasticMake({
         \ 'makeprg': makeprg,
-        \ 'errorformat': errorformat })
+        \ 'errorformat': errorformat,
+        \ 'postprocess': ['guards'] })
 
     for e in loclist
         let e['col'] += 1
     endfor
-
-    call self.setWantSort(1)
 
     return loclist
 endfunction

--- a/bundle/syntastic/syntax_checkers/javascript/flow.vim
+++ b/bundle/syntastic/syntax_checkers/javascript/flow.vim
@@ -1,0 +1,56 @@
+"============================================================================
+"File:        flow.vim
+"Description: Javascript syntax checker - using flow
+"Maintainer:  Michael Robinson <mike@pagesofinterest.net>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists('g:loaded_syntastic_javascript_flow_checker')
+    finish
+endif
+let g:loaded_syntastic_javascript_flow_checker = 1
+
+if !exists('g:syntastic_javascript_flow_sort')
+    let g:syntastic_javascript_flow_sort = 1
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_javascript_flow_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+        \ 'exe_after': 'check',
+        \ 'args_after': '--show-all-errors --json' })
+
+    let errorformat =
+        \ '%f:%l:%c:%n: %m,' .
+        \ '%f:%l:%c: %m'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'preprocess': 'flow',
+        \ 'defaults': {'type': 'E'} })
+
+    for e in loclist
+        if get(e, 'col', 0) && get(e, 'nr', 0)
+            let e['hl'] = '\%>' . (e['col'] - 1) . 'c\%<' . (e['nr'] + 1) . 'c'
+            let e['nr'] = 0
+        endif
+    endfor
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'javascript',
+    \ 'name': 'flow'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/javascript/jscs.vim
+++ b/bundle/syntastic/syntax_checkers/javascript/jscs.vim
@@ -14,6 +14,10 @@ if exists("g:loaded_syntastic_javascript_jscs_checker")
 endif
 let g:loaded_syntastic_javascript_jscs_checker = 1
 
+if !exists('g:syntastic_javascript_jscs_sort')
+    let g:syntastic_javascript_jscs_sort = 1
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -22,16 +26,12 @@ function! SyntaxCheckers_javascript_jscs_GetLocList() dict
 
     let errorformat = '%f:%t:%l:%c:%m'
 
-    let loclist = SyntasticMake({
+    return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'subtype': 'Style',
         \ 'preprocess': 'checkstyle',
         \ 'returns': [0, 2] })
-
-    call self.setWantSort(1)
-
-    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/javascript/jshint.vim
+++ b/bundle/syntastic/syntax_checkers/javascript/jshint.vim
@@ -14,6 +14,10 @@ if exists('g:loaded_syntastic_javascript_jshint_checker')
 endif
 let g:loaded_syntastic_javascript_jshint_checker = 1
 
+if !exists('g:syntastic_javascript_jshint_sort')
+    let g:syntastic_javascript_jshint_sort = 1
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -22,7 +26,10 @@ function! SyntaxCheckers_javascript_jshint_IsAvailable() dict
     if !executable(self.getExec())
         return 0
     endif
+
     let s:jshint_version = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+    call self.log(self.getExec() . ' version =', s:jshint_version)
+
     return syntastic#util#versionIsAtLeast(s:jshint_version, [1])
 endfunction
 
@@ -39,8 +46,6 @@ function! SyntaxCheckers_javascript_jshint_GetLocList() dict
     let errorformat = s:jshint_new ?
         \ '%A%f: line %l\, col %v\, %m \(%t%*\d\)' :
         \ '%E%f: line %l\, col %v\, %m'
-
-    call self.setWantSort(1)
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/bundle/syntastic/syntax_checkers/javascript/jslint.vim
+++ b/bundle/syntastic/syntax_checkers/javascript/jslint.vim
@@ -8,8 +8,8 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
-"Tested with jslint 0.1.4.
 "============================================================================
+
 if exists("g:loaded_syntastic_javascript_jslint_checker")
     finish
 endif

--- a/bundle/syntastic/syntax_checkers/javascript/jsxhint.vim
+++ b/bundle/syntastic/syntax_checkers/javascript/jsxhint.vim
@@ -19,10 +19,14 @@ set cpo&vim
 
 function! SyntaxCheckers_javascript_jsxhint_IsAvailable() dict
     let jsxhint_version = system(self.getExecEscaped() . ' --version')
-    return
-        \ v:shell_error == 0 &&
-        \ jsxhint_version =~# '\m^JSXHint\>' &&
-        \ syntastic#util#versionIsAtLeast(syntastic#util#parseVersion(jsxhint_version), [0, 4, 1])
+    if v:shell_error || (jsxhint_version !~# '\m^JSXHint\>')
+        return 0
+    endif
+
+    let ver = syntastic#util#parseVersion(jsxhint_version)
+    call self.log(self.getExec() . ' version =', ver)
+
+    return syntastic#util#versionIsAtLeast(ver, [0, 4, 1])
 endfunction
 
 function! SyntaxCheckers_javascript_jsxhint_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/less/lessc.vim
+++ b/bundle/syntastic/syntax_checkers/less/lessc.vim
@@ -10,13 +10,6 @@
 "
 "============================================================================
 
-" To send additional options to less use the variable g:syntastic_less_options.
-" The default is
-"   let g:syntastic_less_options = "--no-color"
-"
-" To use less-lint instead of less set the variable
-" g:syntastic_less_use_less_lint.
-
 if exists("g:loaded_syntastic_less_lessc_checker")
     finish
 endif
@@ -33,9 +26,10 @@ endif
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:node_file = 'node ' . syntastic#util#shescape(expand('<sfile>:p:h') . syntastic#util#Slash() . 'less-lint.js')
+let s:node_file = 'node ' . syntastic#util#shescape(expand('<sfile>:p:h', 1) . syntastic#util#Slash() . 'less-lint.js')
 
 function! SyntaxCheckers_less_lessc_IsAvailable() dict
+    call self.log('g:syntastic_less_use_less_lint =', g:syntastic_less_use_less_lint)
     return g:syntastic_less_use_less_lint ? executable('node') : executable(self.getExec())
 endfunction
 
@@ -58,6 +52,7 @@ function! SyntaxCheckers_less_lessc_GetLocList() dict
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
+        \ 'postprocess': ['guards'],
         \ 'defaults': {'bufnr': bufnr(""), 'text': "Syntax error"} })
 endfunction
 

--- a/bundle/syntastic/syntax_checkers/limbo/limbo.vim
+++ b/bundle/syntastic/syntax_checkers/limbo/limbo.vim
@@ -27,7 +27,7 @@ function! SyntaxCheckers_limbo_limbo_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'args_before': include . '-w' . output })
 
     let errorformat = '%E%f:%l:%m'
-    if expand('%') =~# '\m\.m$'
+    if expand('%', 1) =~# '\m\.m$'
         let errorformat = '%-G%f:%l: near ` EOF ` : no implementation module,' . errorformat
     endif
 

--- a/bundle/syntastic/syntax_checkers/lisp/clisp.vim
+++ b/bundle/syntastic/syntax_checkers/lisp/clisp.vim
@@ -19,9 +19,13 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_lisp_clisp_GetLocList() dict
+    let tmpdir = syntastic#util#tmpdir()
+    let out = tmpdir != '.' ? ('-o ' . syntastic#util#shescape(tmpdir . syntastic#util#Slash() . 'syntastic_' . getpid())) : ''
+
     let makeprg = self.makeprgBuild({
         \ 'args_after': '-q',
-        \ 'fname_before': '-c' })
+        \ 'fname_before': '-c',
+        \ 'post_args_after': out })
 
     let errorformat  =
         \ '%-G;%.%#,' .
@@ -33,10 +37,14 @@ function! SyntaxCheckers_lisp_clisp_GetLocList() dict
         \ '%Z %m,' .
         \ '%-G%.%#'
 
-    return SyntasticMake({
+    let loclist = SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'defaults': {'bufnr': bufnr('')} })
+
+    call syntastic#util#rmrf(tmpdir)
+
+    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/lua/luac.vim
+++ b/bundle/syntastic/syntax_checkers/lua/luac.vim
@@ -47,7 +47,7 @@ endfunction
 function! SyntaxCheckers_lua_luac_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'args_after': '-p' })
 
-    let errorformat =  'luac: %#%f:%l: %m'
+    let errorformat = 'luac: %#%f:%l: %m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/bundle/syntastic/syntax_checkers/lua/luacheck.vim
+++ b/bundle/syntastic/syntax_checkers/lua/luacheck.vim
@@ -1,0 +1,67 @@
+"============================================================================
+"File:        luacheck.vim
+"Description: Lua static analysis using luacheck
+"Maintainer:  Thiago Bastos <tbastos@tbastos.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists("g:loaded_syntastic_lua_luacheck_checker")
+    finish
+endif
+let g:loaded_syntastic_lua_luacheck_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_lua_luacheck_GetHighlightRegex(item)
+    let term = matchstr(a:item['text'], '\m''\zs\S\+\ze''')
+    if term != ''
+        return '\V\<' . escape(term, '\') . '\>'
+    endif
+
+    let term = matchstr(a:item['text'], '\m\(accessing undefined\|setting non-standard global\|' .
+                \ 'setting non-module global\|unused global\) variable \zs\S\+')
+    if term == ''
+        let term = matchstr(a:item['text'], '\mvariable \zs\S\+\ze was previously defined')
+    endif
+    if term == ''
+        let term = matchstr(a:item['text'], '\munused \(variable\|argument\|loop variable\) \zs\S\+')
+    endif
+    if term == ''
+        let term = matchstr(a:item['text'], '\m\(value assigned to variable\|value of argument\|' .
+                \ 'value of loop variable\) \zs\S\+')
+    endif
+    if term == ''
+        let term = matchstr(a:item['text'], '\mvariable \zs\S\+\ze is never set')
+    endif
+
+    return term != '' ? '\V\<' . escape(term, '\') . '\>' : ''
+endfunction
+
+function! SyntaxCheckers_lua_luacheck_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args_after': '--no-color' })
+
+    let errorformat =
+        \ '%f:%l:%c: %m,'.
+        \ '%-G%.%#'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'subtype': 'Style',
+        \ 'defaults': { 'type': 'W' },
+        \ 'returns': [0, 1, 2] })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'lua',
+    \ 'name': 'luacheck' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/markdown/mdl.vim
+++ b/bundle/syntastic/syntax_checkers/markdown/mdl.vim
@@ -1,0 +1,45 @@
+"============================================================================
+"File:        mdl.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Charles Beynon <etothepiipower at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists("g:loaded_syntastic_markdown_mdl_checker")
+    finish
+endif
+let g:loaded_syntastic_markdown_mdl_checker = 1
+
+if !exists('g:syntastic_markdown_mdl_sort')
+    let g:syntastic_markdown_mdl_sort = 1
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_markdown_mdl_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args': '--warnings' })
+
+    let errorformat =
+        \ '%E%f:%l: %m,'.
+        \ '%W%f: Kramdown Warning: %m found on line %l'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'subtype': 'Style' })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'markdown',
+    \ 'name': 'mdl'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/nasm/nasm.vim
+++ b/bundle/syntastic/syntax_checkers/nasm/nasm.vim
@@ -21,7 +21,7 @@ set cpo&vim
 function! SyntaxCheckers_nasm_nasm_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'args_after': '-X gnu -f elf' .
-        \       ' -I ' . syntastic#util#shescape(expand("%:p:h") . "/") .
+        \       ' -I ' . syntastic#util#shescape(expand('%:p:h', 1) . '/') .
         \       ' ' . syntastic#c#NullOutput() })
 
     let errorformat = '%f:%l: %t%*[^:]: %m'

--- a/bundle/syntastic/syntax_checkers/nroff/igor.vim
+++ b/bundle/syntastic/syntax_checkers/nroff/igor.vim
@@ -1,0 +1,25 @@
+"============================================================================
+"File:        igor.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_nroff_igor_checker')
+    finish
+endif
+let g:loaded_syntastic_nroff_igor_checker = 1
+
+runtime! syntax_checkers/docbk/*.vim
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'nroff',
+    \ 'name': 'igor',
+    \ 'redirect': 'docbk/igor'})
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/objc/gcc.vim
+++ b/bundle/syntastic/syntax_checkers/objc/gcc.vim
@@ -26,7 +26,8 @@ function! SyntaxCheckers_objc_gcc_IsAvailable() dict
     if !exists('g:syntastic_objc_compiler')
         let g:syntastic_objc_compiler = executable(self.getExec()) ? self.getExec() : 'clang'
     endif
-    return executable(expand(g:syntastic_objc_compiler))
+    call self.log('g:syntastic_objc_compiler =', g:syntastic_objc_compiler)
+    return executable(expand(g:syntastic_objc_compiler, 1))
 endfunction
 
 function! SyntaxCheckers_objc_gcc_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/objc/oclint.vim
+++ b/bundle/syntastic/syntax_checkers/objc/oclint.vim
@@ -8,13 +8,6 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "============================================================================
-"
-" The setting 'g:syntastic_oclint_config_file' allows you to define a file
-" that contains additional compiler arguments like include directories or
-" CFLAGS. The file is expected to contain one option per line. If none is
-" given the filename defaults to '.syntastic_oclint_config':
-"
-"   let g:syntastic_oclint_config_file = '.config'
 
 if exists("g:loaded_syntastic_objc_oclint_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/objcpp/gcc.vim
+++ b/bundle/syntastic/syntax_checkers/objcpp/gcc.vim
@@ -26,7 +26,8 @@ function! SyntaxCheckers_objcpp_gcc_IsAvailable() dict
     if !exists('g:syntastic_c_compiler')
         let g:syntastic_objcpp_compiler = executable(self.getExec()) ? self.getExec() : 'clang'
     endif
-    return executable(expand(g:syntastic_objcpp_compiler))
+    call self.log('g:syntastic_objcpp_compiler =', g:syntastic_objcpp_compiler)
+    return executable(expand(g:syntastic_objcpp_compiler, 1))
 endfunction
 
 function! SyntaxCheckers_objcpp_gcc_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/objcpp/oclint.vim
+++ b/bundle/syntastic/syntax_checkers/objcpp/oclint.vim
@@ -8,13 +8,6 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "============================================================================
-"
-" The setting 'g:syntastic_oclint_config_file' allows you to define a file
-" that contains additional compiler arguments like include directories or
-" CFLAGS. The file is expected to contain one option per line. If none is
-" given the filename defaults to '.syntastic_oclint_config':
-"
-"   let g:syntastic_oclint_config_file = '.config'
 
 if exists("g:loaded_syntastic_objcpp_oclint_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/ocaml/camlp4o.vim
+++ b/bundle/syntastic/syntax_checkers/ocaml/camlp4o.vim
@@ -9,44 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" The more reliable way to check for a single .ml file is to use ocamlc.
-" You can do that setting this in your .vimrc:
-"
-"   let g:syntastic_ocaml_use_ocamlc = 1
-" It's possible to use ocamlc in conjuction with Jane Street's Core. In order
-" to do that, you have to specify this in your .vimrc:
-"
-"   let g:syntastic_ocaml_use_janestreet_core = 1
-"   let g:syntastic_ocaml_janestreet_core_dir = <path>
-"
-" Where path is the path to your core installation (usually a collection of
-" .cmx and .cmxa files).
-"
-"
-" By default the camlp4o preprocessor is used to check the syntax of .ml, and .mli files,
-" ocamllex is used to check .mll files and menhir is used to check .mly files.
-" The output is all redirected to /dev/null, nothing is written to the disk.
-"
-" If your source code needs camlp4r then you can define this in your .vimrc:
-"
-"   let g:syntastic_ocaml_camlp4r = 1
-"
-" If you used some syntax extensions, or you want to also typecheck the source
-" code, then you can define this:
-"
-"   let g:syntastic_ocaml_use_ocamlbuild = 1
-"
-" This will run ocamlbuild <name>.inferred.mli, so it will write to your _build
-" directory (and possibly rebuild your myocamlbuild.ml plugin), only enable this
-" if you are ok with that.
-"
-" If you are using syntax extensions / external libraries and have a properly
-" set up _tags (and myocamlbuild.ml file) then it should just work
-" to enable this flag and get syntax / type checks through syntastic.
-"
-" For best results your current directory should be the project root
-" (same situation if you want useful output from :make).
 
 if exists("g:loaded_syntastic_ocaml_camlp4o_checker")
     finish
@@ -71,7 +33,7 @@ if !exists('g:syntastic_ocaml_use_ocamlc') || !executable('ocamlc')
 endif
 
 if !exists('g:syntastic_ocaml_use_janestreet_core')
-    let g:syntastic_ocaml_use_ocamlc = 0
+    let g:syntastic_ocaml_use_janestreet_core = 0
 endif
 
 if !exists('g:syntastic_ocaml_use_ocamlbuild') || !executable("ocamlbuild")
@@ -113,7 +75,7 @@ endfunction
 function! s:GetOcamlcMakeprg()
     if g:syntastic_ocaml_use_janestreet_core
         let build_cmd = "ocamlc -I "
-        let build_cmd .= expand(g:syntastic_ocaml_janestreet_core_dir)
+        let build_cmd .= expand(g:syntastic_ocaml_janestreet_core_dir, 1)
         let build_cmd .= " -c " . syntastic#util#shexpand('%')
         return build_cmd
     else
@@ -131,7 +93,7 @@ function! s:GetOtherMakeprg()
     "
     "TODO: should use throw/catch instead of returning an empty makeprg
 
-    let extension = expand('%:e')
+    let extension = expand('%:e', 1)
     let makeprg = ""
 
     if stridx(extension, 'mly') >= 0 && executable("menhir")

--- a/bundle/syntastic/syntax_checkers/perl/perl.vim
+++ b/bundle/syntastic/syntax_checkers/perl/perl.vim
@@ -26,16 +26,6 @@
 " References:
 "
 " - http://perldoc.perl.org/perlrun.html#*-c*
-"
-" Checker options:
-"
-" - g:syntastic_perl_interpreter (string; default: 'perl')
-"   The perl interpreter to use.
-"
-" - g:syntastic_perl_lib_path (list; default: [])
-"   List of include directories to be added to the perl command line. Example:
-"
-"       let g:syntastic_perl_lib_path = [ './lib', './lib/auto' ]
 
 if exists('g:loaded_syntastic_perl_perl_checker')
     finish

--- a/bundle/syntastic/syntax_checkers/perl/perlcritic.vim
+++ b/bundle/syntastic/syntax_checkers/perl/perlcritic.vim
@@ -9,20 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" For details about perlcritic see:
-"
-" - http://perlcritic.tigris.org/
-" - https://metacpan.org/module/Perl::Critic
-"
-" Checker options:
-"
-" - g:syntastic_perl_perlcritic_thres (integer; default: 5)
-"   error threshold: policy violations with a severity above this
-"   value are highlighted as errors, the others are warnings
-"
-" - g:syntastic_perl_perlcritic_args (string; default: empty)
-"   command line options to pass to perlcritic
 
 if exists("g:loaded_syntastic_perl_perlcritic_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/php/php.vim
+++ b/bundle/syntastic/syntax_checkers/php/php.vim
@@ -38,7 +38,8 @@ function! SyntaxCheckers_php_php_GetLocList() dict
 
     return SyntasticMake({
         \ 'makeprg': makeprg,
-        \ 'errorformat': errorformat })
+        \ 'errorformat': errorformat,
+        \ 'postprocess': ['guards'] })
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/php/phpcs.vim
+++ b/bundle/syntastic/syntax_checkers/php/phpcs.vim
@@ -9,9 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" See here for details of phpcs
-"    - phpcs (see http://pear.php.net/package/PHP_CodeSniffer)
 
 if exists("g:loaded_syntastic_php_phpcs_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/php/phplint.vim
+++ b/bundle/syntastic/syntax_checkers/php/phplint.vim
@@ -1,0 +1,91 @@
+"============================================================================
+"File:        phplint.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists("g:loaded_syntastic_php_phplint_checker")
+    finish
+endif
+let g:loaded_syntastic_php_phplint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_php_phplint_GetHighlightRegex(item)
+    let term = matchstr(a:item['text'], '\munresolved function \zs\S\+\ze')
+    if term != ''
+        return '\V' . escape(term, '\')
+    endif
+    let term = matchstr(a:item['text'], '\m\(class\|function\|method\) \zs\S\+\ze was declared as')
+    if term != ''
+        return '\V' . escape(term, '\')
+    endif
+    let term = matchstr(a:item['text'], '\maccess forbidden to \(private\|protected\) \(class\|constant\|method\|variable\|\(private\|protected\) property\) \zs\S\+\ze')
+    if term != ''
+        return '\V' . escape(term, '\')
+    endif
+    let term = matchstr(a:item['text'], '\musing deprecated \(class\|constant\|method\|property\|variable\) \zs\S\+\ze')
+    if term != ''
+        return '\V' . escape(term, '\')
+    endif
+    let term = matchstr(a:item['text'], '\munresolved function \zs\S\+\ze')
+    if term != ''
+        return '\V' . escape(term, '\')
+    endif
+    let term = matchstr(a:item['text'], '\munresolved function \zs\S\+\ze')
+    if term != ''
+        return '\V' . escape(term, '\')
+    endif
+    let term = matchstr(a:item['text'], '\munresolved function \zs\S\+\ze')
+    return term != '' ? '\V' . escape(term, '\') : ''
+endfunction
+
+function! SyntaxCheckers_php_phplint_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+        \ 'args_after':
+        \   '--print-file-name ' .
+        \   '--print-line-numbers ' .
+        \   '--print-column-number ' .
+        \   '--print-errors ' .
+        \   '--print-warnings ' .
+        \   '--no-print-notices ' .
+        \   '--no-print-context ' .
+        \   '--no-print-source ' .
+        \   '--tab-size ' . &tabstop })
+
+    let errorformat =
+        \ '%E%f:%l:%v: %tRROR: %m,' .
+        \ '%W%f:%l:%v: %tarning: %m,' .
+        \ '%+C%\t%.%#,' .
+        \ '%-G%.%#'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'postprocess': ['compressWhitespace'],
+        \ 'subtype': 'Style',
+        \ 'returns': [0, 1] })
+
+    for e in loclist
+        let e['text'] = substitute(e['text'], '\m \(Hint\|Examples\):.*', '', '')
+    endfor
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'php',
+    \ 'name': 'phplint',
+    \ 'exec': 'phpl' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/php/phpmd.vim
+++ b/bundle/syntastic/syntax_checkers/php/phpmd.vim
@@ -9,9 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" See here for details of phpmd
-"   - phpmd (see http://phpmd.org)
 
 if exists("g:loaded_syntastic_php_phpmd_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/puppet/puppet.vim
+++ b/bundle/syntastic/syntax_checkers/puppet/puppet.vim
@@ -19,9 +19,12 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_puppet_puppet_GetLocList() dict
-    let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version 2>' . syntastic#util#DevNull())
+    if !exists('s:puppet_version')
+        let s:puppet_version = syntastic#util#getVersion(self.getExecEscaped() . ' --version 2>' . syntastic#util#DevNull())
+        call self.log(self.getExec() . ' version =', s:puppet_version)
+    endif
 
-    if syntastic#util#versionIsAtLeast(ver, [2,7,0])
+    if syntastic#util#versionIsAtLeast(s:puppet_version, [2,7,0])
         let args = 'parser validate --color=false'
     else
         let args = '--color=false --parseonly'
@@ -32,8 +35,8 @@ function! SyntaxCheckers_puppet_puppet_GetLocList() dict
     let errorformat =
         \ '%-Gerr: Try ''puppet help parser validate'' for usage,' .
         \ '%-GError: Try ''puppet help parser validate'' for usage,' .
-        \ '%Eerr: Could not parse for environment %*[a-z]: %m at %f:%l,' .
-        \ '%EError: Could not parse for environment %*[a-z]: %m at %f:%l'
+        \ '%A%t%*[a-zA-Z]: %m at %f:%l:%c,' .
+        \ '%A%t%*[a-zA-Z]: %m at %f:%l'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/bundle/syntastic/syntax_checkers/puppet/puppetlint.vim
+++ b/bundle/syntastic/syntax_checkers/puppet/puppetlint.vim
@@ -19,11 +19,16 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_puppet_puppetlint_IsAvailable() dict
-    return
-        \ executable("puppet") &&
-        \ executable(self.getExec()) &&
-        \ syntastic#util#versionIsAtLeast(syntastic#util#getVersion(
-        \       self.getExecEscaped() . ' --version 2>' . syntastic#util#DevNull()), [0,1,10])
+    call self.log("executable('puppet') = " . executable('puppet') . ', ' .
+        \ "executable(" . string(self.getExec()) . ") = " . executable(self.getExec()))
+    if !executable('puppet') || !executable(self.getExec())
+        return 0
+    endif
+
+    let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version 2>' . syntastic#util#DevNull())
+    call self.log(self.getExec() . ' version =', ver)
+
+    return syntastic#util#versionIsAtLeast(ver, [0, 1, 10])
 endfunction
 
 function! SyntaxCheckers_puppet_puppetlint_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/python/frosted.vim
+++ b/bundle/syntastic/syntax_checkers/python/frosted.vim
@@ -42,7 +42,7 @@ function! SyntaxCheckers_python_frosted_GetLocList() dict
         if len(parts) >= 4
             let e["type"] = parts[1][0]
             let e["text"] = parts[3] . ' [' . parts[1] . ']'
-            let e["hl"] = '\V' . escape(parts[2], '\')
+            let e["hl"] = '\V\<' . escape(parts[2], '\') . '\>'
         elseif e["text"] =~? '\v^I\d+:'
             let e["valid"] = 0
         else

--- a/bundle/syntastic/syntax_checkers/python/mypy.vim
+++ b/bundle/syntastic/syntax_checkers/python/mypy.vim
@@ -1,0 +1,35 @@
+"============================================================================
+"File:        mypy.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Author:      Russ Hewgill <Russ dot Hewgill at gmail dot com>
+"
+"============================================================================
+
+if exists("g:loaded_syntastic_python_mypy_checker")
+    finish
+endif
+let g:loaded_syntastic_python_mypy_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_python_mypy_GetLocList() dict
+    let makeprg = self.makeprgBuild({})
+
+    let errorformat = '%f\, line %l: %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': { 'type': 'E' },
+        \ 'returns': [0, 1] })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'python',
+    \ 'name': 'mypy'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/python/pep257.vim
+++ b/bundle/syntastic/syntax_checkers/python/pep257.vim
@@ -2,8 +2,6 @@
 "File:        pep257.vim
 "Description: Docstring style checking plugin for syntastic.vim
 "============================================================================
-"
-" For details about pep257 see: https://github.com/GreenSteam/pep257
 
 if exists('g:loaded_syntastic_python_pep257_checker')
     finish
@@ -15,8 +13,9 @@ set cpo&vim
 
 function! SyntaxCheckers_python_pep257_GetLocList() dict
     if !exists('s:pep257_new')
-        let s:pep257_new = syntastic#util#versionIsAtLeast(syntastic#util#getVersion(
-            \ self.getExecEscaped() . ' --version'), [0, 3])
+        let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+        call self.log(self.getExec() . ' version =', ver)
+        let s:pep257_new = syntastic#util#versionIsAtLeast(ver, [0, 3])
     endif
 
     let makeprg = self.makeprgBuild({})

--- a/bundle/syntastic/syntax_checkers/python/pep8.vim
+++ b/bundle/syntastic/syntax_checkers/python/pep8.vim
@@ -9,8 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" For details about pep8 see: https://github.com/jcrocholl/pep8
 
 if exists("g:loaded_syntastic_python_pep8_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/python/prospector.vim
+++ b/bundle/syntastic/syntax_checkers/python/prospector.vim
@@ -1,0 +1,78 @@
+"============================================================================
+"File:        prospector.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists("g:loaded_syntastic_python_prospector_checker")
+    finish
+endif
+let g:loaded_syntastic_python_prospector_checker = 1
+
+if !exists('g:syntastic_python_prospector_sort')
+    let g:syntastic_python_prospector_sort = 1
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_python_prospector_IsAvailable() dict
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+    call self.log(self.getExec() . ' version =', ver)
+
+    return syntastic#util#versionIsAtLeast(ver, [0, 7])
+endfunction
+
+function! SyntaxCheckers_python_prospector_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+        \ 'args': '--external-config merge',
+        \ 'args_after': '--messages-only --absolute-paths --die-on-tool-error --zero-exit --output-format json' })
+
+    let errorformat = '%f:%l:%c: %m'
+
+    let env = syntastic#util#isRunningWindows() ? {} : { 'TERM': 'dumb' }
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'env': env,
+        \ 'preprocess': 'prospector',
+        \ 'returns': [0] })
+
+    for e in loclist
+        if e['text'] =~# '\v\[%(dodgy|mccabe|pep8|pep257|pyroma)\]$'
+            let e['subtype'] = 'Style'
+        endif
+
+        if e['text'] =~# '\v\[pylint\]$'
+            let e['type'] = e['text'] =~? '\m^[CRW]' ? 'W' : 'E'
+        elseif e['text'] =~# '\v\[%(frosted|pep8)\]$'
+            let e['type'] = e['text'] =~? '\m^W' ? 'W' : 'E'
+        elseif e['text'] =~# '\v\[%(dodgy|pyroma|vulture)\]$'
+            let e['type'] = 'W'
+        else
+            let e['type'] = 'E'
+        endif
+    endfor
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'python',
+    \ 'name': 'prospector'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/python/pylama.vim
+++ b/bundle/syntastic/syntax_checkers/python/pylama.vim
@@ -15,6 +15,10 @@ if exists('g:loaded_syntastic_python_pylama_checker')
 endif
 let g:loaded_syntastic_python_pylama_checker = 1
 
+if !exists('g:syntastic_python_pylama_sort')
+    let g:syntastic_python_pylama_sort = 1
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -54,8 +58,6 @@ function! SyntaxCheckers_python_pylama_GetLocList() dict
             let e['subtype'] = 'Style'
         endif
     endfor
-
-    call self.setWantSort(1)
 
     return loclist
 endfunction

--- a/bundle/syntastic/syntax_checkers/python/pylint.vim
+++ b/bundle/syntastic/syntax_checkers/python/pylint.vim
@@ -10,20 +10,48 @@ if exists("g:loaded_syntastic_python_pylint_checker")
 endif
 let g:loaded_syntastic_python_pylint_checker = 1
 
-let s:pylint_new = -1
+if !exists('g:syntastic_python_pylint_sort')
+    let g:syntastic_python_pylint_sort = 1
+endif
 
 let s:save_cpo = &cpo
 set cpo&vim
 
+let s:pylint_new = -1
+
 function! SyntaxCheckers_python_pylint_IsAvailable() dict
-    let exe = self.getExec()
-    let s:pylint_new = executable(exe) ? s:PylintNew(exe) : -1
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    try
+        " On Windows the version is shown as "pylint-script.py 1.0.0".
+        " On Gentoo Linux it's "pylint-python2.7 0.28.0".
+        " On NixOS, that would be ".pylint-wrapped 0.26.0".
+        " On Arch Linux it's "pylint2 1.1.0".
+        " On new-ish Fedora it's "python3-pylint 1.2.0".
+        " Have you guys considered switching to creative writing yet? ;)
+
+        let pylint_version = filter( split(system(self.getExecEscaped() . ' --version'), '\m, \=\|\n'),
+            \ 'v:val =~# ''\m^\(python[-0-9]*-\|\.\)\=pylint[-0-9]*\>''' )[0]
+        let ver = syntastic#util#parseVersion(substitute(pylint_version, '\v^\S+\s+', '', ''))
+
+        call self.log(self.getExec() . ' version =', ver)
+
+        let s:pylint_new = syntastic#util#versionIsAtLeast(ver, [1])
+    catch /\m^Vim\%((\a\+)\)\=:E684/
+        call syntastic#log#error("checker python/pylint: can't parse version string (abnormal termination?)")
+        let s:pylint_new = -1
+    endtry
+
     return s:pylint_new >= 0
 endfunction
 
 function! SyntaxCheckers_python_pylint_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args_after': (s:pylint_new ? '-f text --msg-template="{path}:{line}:{column}:{C}: [{symbol}] {msg}" -r n' : '-f parseable -r n -i y') })
+        \ 'args_after': (s:pylint_new ?
+        \       '-f text --msg-template="{path}:{line}:{column}:{C}: [{symbol}] {msg}" -r n' :
+        \       '-f parseable -r n -i y') })
 
     let errorformat =
         \ '%A%f:%l:%c:%t: %m,' .
@@ -57,27 +85,7 @@ function! SyntaxCheckers_python_pylint_GetLocList() dict
         let e['vcol'] = 0
     endfor
 
-    call self.setWantSort(1)
-
     return loclist
-endfunction
-
-function! s:PylintNew(exe)
-    let exe = syntastic#util#shescape(a:exe)
-    try
-        " On Windows the version is shown as "pylint-script.py 1.0.0".
-        " On Gentoo Linux it's "pylint-python2.7 0.28.0".
-        " On NixOS, that would be ".pylint-wrapped 0.26.0".
-        " On Arch Linux it's "pylint2 1.1.0".
-        " Have you guys considered switching to creative writing yet? ;)
-        let pylint_version = filter(split(system(exe . ' --version'), '\m, \=\|\n'), 'v:val =~# ''\m^\.\=pylint[-0-9]*\>''')[0]
-        let pylint_version = substitute(pylint_version, '\v^\S+\s+', '', '')
-        let ret = syntastic#util#versionIsAtLeast(syntastic#util#parseVersion(pylint_version), [1])
-    catch /\m^Vim\%((\a\+)\)\=:E684/
-        call syntastic#log#error("checker python/pylint: can't parse version string (abnormal termination?)")
-        let ret = -1
-    endtry
-    return ret
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/python/python.vim
+++ b/bundle/syntastic/syntax_checkers/python/python.vim
@@ -18,11 +18,17 @@ let g:loaded_syntastic_python_python_checker = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:compiler = expand('<sfile>:p:h') . syntastic#util#Slash() . 'compile.py'
+let s:compiler = expand('<sfile>:p:h', 1) . syntastic#util#Slash() . 'compile.py'
 
 function! SyntaxCheckers_python_python_IsAvailable() dict
-    return executable(self.getExec()) &&
-        \ syntastic#util#versionIsAtLeast(syntastic#util#getVersion(self.getExecEscaped() . ' --version'), [2, 6])
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+    call self.log(self.getExec() . ' version =', ver)
+
+    return syntastic#util#versionIsAtLeast(ver, [2, 6])
 endfunction
 
 function! SyntaxCheckers_python_python_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/r/lint.vim
+++ b/bundle/syntastic/syntax_checkers/r/lint.vim
@@ -19,6 +19,10 @@ if !exists('g:syntastic_r_lint_styles')
     let g:syntastic_r_lint_styles = 'lint.style'
 endif
 
+if !exists('g:syntastic_r_lint_sort')
+    let g:syntastic_r_lint_sort = 1
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -64,8 +68,6 @@ function! SyntaxCheckers_r_lint_GetLocList() dict
             call remove(e, 'subtype')
         endif
     endfor
-
-    call self.setWantSort(1)
 
     return loclist
 endfunction

--- a/bundle/syntastic/syntax_checkers/racket/code-ayatollah.vim
+++ b/bundle/syntastic/syntax_checkers/racket/code-ayatollah.vim
@@ -19,11 +19,15 @@ if !exists('g:syntastic_racket_code_ayatollah_script')
     let g:syntastic_racket_code_ayatollah_script = 'code-ayatollah.rkt'
 endif
 
+if !exists('g:syntastic_racket_code_ayatollah_sort')
+    let g:syntastic_racket_code_ayatollah_sort = 1
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_racket_code_ayatollah_IsAvailable() dict
-    let s:script = expand(g:syntastic_racket_code_ayatollah_script)
+    let s:script = expand(g:syntastic_racket_code_ayatollah_script, 1)
     return executable(self.getExec()) && filereadable(s:script)
 endfunction
 
@@ -43,8 +47,6 @@ function! SyntaxCheckers_racket_code_ayatollah_GetLocList() dict
     for e in loclist
         let e['col'] += 1
     endfor
-
-    call self.setWantSort(1)
 
     return loclist
 endfunction

--- a/bundle/syntastic/syntax_checkers/rnc/rnv.vim
+++ b/bundle/syntastic/syntax_checkers/rnc/rnv.vim
@@ -1,0 +1,38 @@
+"============================================================================
+"File:        rnv.vim
+"Description: RelaxNG RNV syntax checking plugin for syntastic.vim
+"Maintainer:  Remko Tronçon <remko at el-tramo dot be>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists("g:loaded_syntastic_rnc_rnv_checker")
+    finish
+endif
+let g:loaded_syntastic_rnc_rnv_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_rnc_rnv_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args': '-c' })
+
+    let errorformat =
+        \ '%f:%l:%c: %trror: %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'rnc',
+    \ 'name': 'rnv'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/rst/rst2pseudoxml.vim
+++ b/bundle/syntastic/syntax_checkers/rst/rst2pseudoxml.vim
@@ -1,6 +1,6 @@
 "============================================================================
 "File:        rst.vim
-"Description: Syntax checking plugin for docutil's reStructuredText files
+"Description: Syntax checking plugin for docutils' reStructuredText files
 "Maintainer:  James Rowe <jnrowe at gmail dot com>
 "License:     This program is free software. It comes without any warranty,
 "             to the extent permitted by applicable law. You can redistribute

--- a/bundle/syntastic/syntax_checkers/ruby/mri.vim
+++ b/bundle/syntastic/syntax_checkers/ruby/mri.vim
@@ -21,6 +21,7 @@ set cpo&vim
 function! SyntaxCheckers_ruby_mri_IsAvailable() dict
     if !exists('g:syntastic_ruby_mri_exec') && exists('g:syntastic_ruby_exec')
         let g:syntastic_ruby_mri_exec = g:syntastic_ruby_exec
+        call self.log('g:syntastic_ruby_exec =', g:syntastic_ruby_exec)
     endif
     return executable(self.getExec())
 endfunction
@@ -44,7 +45,7 @@ function! SyntaxCheckers_ruby_mri_GetLocList() dict
     "
     "Which always generate the warning below. Note that ruby >= 1.9.3 includes
     "the word "possibly" in the warning
-    let errorformat = '%-G%.%#warning: %\(possibly %\)%\?useless use of == in void context,'
+    let errorformat = '%-G%\m%.%#warning: %\%%(possibly %\)%\?useless use of == in void context,'
 
     " filter out lines starting with ...
     " long lines are truncated and wrapped in ... %p then returns the wrong

--- a/bundle/syntastic/syntax_checkers/ruby/reek.vim
+++ b/bundle/syntastic/syntax_checkers/ruby/reek.vim
@@ -1,0 +1,59 @@
+"============================================================================
+"File:        reek.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Mindaugas Mozūras
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists("g:loaded_syntastic_ruby_reek_checker")
+    finish
+endif
+let g:loaded_syntastic_ruby_reek_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_ruby_reek_IsAvailable() dict
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+    call self.log(self.getExec() . ' version =', ver)
+
+    return syntastic#util#versionIsAtLeast(ver, [1, 3, 0])
+endfunction
+
+function! SyntaxCheckers_ruby_reek_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args_before': '--no-color --quiet --line-number --single-line' })
+
+    let errorformat =
+        \ '%E%.%#: Racc::ParseError: %f:%l :: %m,' .
+        \ '%W%f:%l: %m'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat })
+
+    for e in loclist
+        if e['type'] ==? 'W'
+            let e['subtype'] = 'Style'
+        endif
+    endfor
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'ruby',
+    \ 'name': 'reek'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/ruby/rubocop.vim
+++ b/bundle/syntastic/syntax_checkers/ruby/rubocop.vim
@@ -9,9 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" In order to use rubocop with the default ruby checker (mri):
-"     let g:syntastic_ruby_checkers = ['mri', 'rubocop']
 
 if exists("g:loaded_syntastic_ruby_rubocop_checker")
     finish
@@ -22,9 +19,14 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_ruby_rubocop_IsAvailable() dict
-    return
-        \ executable(self.getExec()) &&
-        \ syntastic#util#versionIsAtLeast(syntastic#util#getVersion(self.getExecEscaped() . ' --version'), [0, 9, 0])
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+    call self.log(self.getExec() . ' version =', ver)
+
+    return syntastic#util#versionIsAtLeast(ver, [0, 9, 0])
 endfunction
 
 function! SyntaxCheckers_ruby_rubocop_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/ruby/rubylint.vim
+++ b/bundle/syntastic/syntax_checkers/ruby/rubylint.vim
@@ -21,8 +21,9 @@ set cpo&vim
 
 function! SyntaxCheckers_ruby_rubylint_GetLocList() dict
     if !exists('s:rubylint_new')
-        let s:rubylint_new = syntastic#util#versionIsAtLeast(syntastic#util#getVersion(
-            \ self.getExecEscaped() . ' --version'), [2])
+        let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+        call self.log(self.getExec() . ' version =', ver)
+        let s:rubylint_new = syntastic#util#versionIsAtLeast(ver, [2])
     endif
     let makeprg = self.makeprgBuild({ 'args': (s:rubylint_new ? '' : 'analyze ') . '--presenter=syntastic' })
 

--- a/bundle/syntastic/syntax_checkers/sass/sass.vim
+++ b/bundle/syntastic/syntax_checkers/sass/sass.vim
@@ -17,8 +17,12 @@ let g:loaded_syntastic_sass_sass_checker = 1
 
 "sass caching for large files drastically speeds up the checking, but store it
 "in a temp location otherwise sass puts .sass_cache dirs in the users project
-let s:sass_cache_location = tempname()
+let s:sass_cache_location = syntastic#util#tmpdir()
 lockvar s:sass_cache_location
+
+augroup syntastic
+    autocmd VimLeave * call syntastic#util#rmrf(s:sass_cache_location)
+augroup END
 
 "By default do not check partials as unknown variables are a syntax error
 if !exists("g:syntastic_sass_check_partials")
@@ -35,7 +39,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_sass_sass_GetLocList() dict
-    if !g:syntastic_sass_check_partials && expand('%:t')[0] == '_'
+    if !g:syntastic_sass_check_partials && expand('%:t', 1)[0] == '_'
         return []
     endif
 
@@ -43,7 +47,7 @@ function! SyntaxCheckers_sass_sass_GetLocList() dict
         \ 'args_before': '--cache-location ' . s:sass_cache_location . ' ' . s:imports . ' --check' })
 
     let errorformat =
-        \ '%ESyntax %trror: %m,' .
+        \ '%E%\m%\%%(Syntax %\)%\?%trror: %m,' .
         \ '%+C              %.%#,' .
         \ '%C        on line %l of %f\, %.%#,' .
         \ '%C        on line %l of %f,' .

--- a/bundle/syntastic/syntax_checkers/scala/scalastyle.vim
+++ b/bundle/syntastic/syntax_checkers/scala/scalastyle.vim
@@ -1,0 +1,77 @@
+"============================================================================
+"File:        scalastyle.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_scala_scalastyle_checker')
+    finish
+endif
+let g:loaded_syntastic_scala_scalastyle_checker = 1
+
+if !exists('g:syntastic_scala_scalastyle_jar')
+    let g:syntastic_scala_scalastyle_jar = 'scalastyle-batch_2.10.jar'
+endif
+
+if !exists('g:syntastic_scala_scalastyle_config_file')
+    let g:syntastic_scala_scalastyle_config_file = 'scalastyle_config.xml'
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_scala_scalastyle_IsAvailable() dict
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    let jar = expand(g:syntastic_scala_scalastyle_jar, 1)
+    let conf_file = expand(g:syntastic_scala_scalastyle_config_file, 1)
+    call self.log('filereadable(' . string(jar) . ') = ' . filereadable(jar) . ', ' .
+        \ 'filereadable(' . string(conf_file) . ') = ' . filereadable(conf_file))
+
+    return filereadable(jar) && filereadable(conf_file)
+endfunction
+
+function! SyntaxCheckers_scala_scalastyle_GetLocList() dict
+
+    let makeprg = self.makeprgBuild({
+        \ 'exe_after': ['-jar', expand(g:syntastic_scala_scalastyle_jar, 1)],
+        \ 'args_before': ['-q', 'true', '-c', expand(g:syntastic_scala_scalastyle_config_file, 1)] })
+
+    let errorformat =
+        \ '%trror file=%f message=%m line=%l column=%c,' .
+        \ '%trror file=%f message=%m line=%l,' .
+        \ '%tarning file=%f message=%m line=%l column=%c,' .
+        \ '%tarning file=%f message=%m line=%l'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'subtype': 'Style',
+        \ 'returns': [0, 1] })
+
+    for e in loclist
+        if has_key(e, 'col')
+            let e['col'] += 1
+        endif
+    endfor
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'scala',
+    \ 'name': 'scalastyle',
+    \ 'exec': 'java'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/scss/scss_lint.vim
+++ b/bundle/syntastic/syntax_checkers/scss/scss_lint.vim
@@ -18,20 +18,36 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_scss_scss_lint_IsAvailable() dict
-    return
-        \ executable(self.getExec()) &&
-        \ syntastic#util#versionIsAtLeast(syntastic#util#getVersion(
-        \       self.getExecEscaped() . ' --version'), [0, 12])
+    if !executable(self.getExec())
+        return 0
+    endif
+
+    let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+    call self.log(self.getExec() . ' version =', ver)
+
+    return syntastic#util#versionIsAtLeast(ver, [0, 12])
 endfunction
 
 function! SyntaxCheckers_scss_scss_lint_GetLocList() dict
     let makeprg = self.makeprgBuild({})
+
     let errorformat = '%f:%l [%t] %m'
-    return SyntasticMake({
+
+    let loclist = SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'subtype': 'Style',
-        \ 'returns': [0, 1, 65] })
+        \ 'returns': [0, 1, 2, 65, 66] })
+
+    let cutoff = strlen('Syntax Error: ')
+    for e in loclist
+        if e['text'][: cutoff-1] ==# 'Syntax Error: '
+            let e['text'] = e['text'][cutoff :]
+        else
+            let e['subtype'] = 'Style'
+        endif
+    endfor
+
+    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/sh/bashate.vim
+++ b/bundle/syntastic/syntax_checkers/sh/bashate.vim
@@ -1,0 +1,48 @@
+"============================================================================
+"File:        bashate.vim
+"Description: Bash script style checking plugin for syntastic.vim
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists("g:loaded_syntastic_sh_bashate_checker")
+    finish
+endif
+let g:loaded_syntastic_sh_bashate_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_sh_bashate_GetLocList() dict
+    let makeprg = self.makeprgBuild({})
+
+    let errorformat =
+        \ '%EE%n: %m,' .
+        \ '%Z - %f: L%l,' .
+        \ '%-G%.%#'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'subtype': 'Style',
+        \ 'returns': [0, 1] })
+
+    for e in loclist
+        let e['text'] = substitute(e['text'], "\\m: '.*", '', '')
+    endfor
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'sh',
+    \ 'name': 'bashate' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/sh/sh.vim
+++ b/bundle/syntastic/syntax_checkers/sh/sh.vim
@@ -19,6 +19,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_sh_sh_IsAvailable() dict
+    call self.log('shell =', s:GetShell())
     return s:IsShellValid()
 endfunction
 
@@ -57,7 +58,7 @@ function! s:GetShell()
         endif
         " try to use env variable in case no shebang could be found
         if b:shell == ''
-            let b:shell = fnamemodify(expand('$SHELL'), ':t')
+            let b:shell = fnamemodify($SHELL, ':t')
         endif
     endif
     return b:shell

--- a/bundle/syntastic/syntax_checkers/slim/slimrb.vim
+++ b/bundle/syntastic/syntax_checkers/slim/slimrb.vim
@@ -20,8 +20,9 @@ set cpo&vim
 
 function! SyntaxCheckers_slim_slimrb_GetLocList() dict
     if !exists('s:slimrb_new')
-        let s:slimrb_new = syntastic#util#versionIsAtLeast(syntastic#util#getVersion(
-            \ self.getExecEscaped() . ' --version 2>'. syntastic#util#DevNull()), [1, 3, 1])
+        let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version 2>'. syntastic#util#DevNull())
+        call self.log(self.getExec() . ' version =', ver)
+        let s:slimrb_new = syntastic#util#versionIsAtLeast(ver, [1, 3, 1])
     endif
 
     let makeprg = self.makeprgBuild({ 'args_after': '-c' })

--- a/bundle/syntastic/syntax_checkers/spec/rpmlint.vim
+++ b/bundle/syntastic/syntax_checkers/spec/rpmlint.vim
@@ -1,0 +1,43 @@
+"============================================================================
+"File:        rpmlint.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_spec_rpmlint_checker')
+    finish
+endif
+let g:loaded_syntastic_spec_rpmlint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_spec_rpmlint_GetLocList() dict
+    let makeprg = self.makeprgBuild({})
+
+    let errorformat =
+        \ '%E%f:%l: E: %m,' .
+        \ '%E%f: E: %m,' .
+        \ '%W%f:%l: W: %m,' .
+        \ '%W%f: W: %m,' .
+        \ '%-G%.%#'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'spec',
+    \ 'name': 'rpmlint'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/tcl/nagelfar.vim
+++ b/bundle/syntastic/syntax_checkers/tcl/nagelfar.vim
@@ -7,10 +7,11 @@
 "             it and/or modify it under the terms of the Do What The Fuck You
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
-"Notes:       Requires nagelfar v1.1.12 or later with support for -H option.
-"             See nagelfar homepage http://nagelfar.berlios.de/.
 "
 "============================================================================
+"
+"Notes:       Requires nagelfar v1.1.12 or later with support for -H option.
+"             See nagelfar homepage http://nagelfar.berlios.de/.
 
 if exists("g:loaded_syntastic_tcl_nagelfar_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/tex/chktex.vim
+++ b/bundle/syntastic/syntax_checkers/tex/chktex.vim
@@ -9,31 +9,22 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" For details about ChkTeX see:
-"
-" http://baruch.ev-en.org/proj/chktex/
-"
-" Checker options:
-"
-" - g:syntastic_tex_chktex_showmsgs (boolean; default: 1)
-"   whether to show informational messages (chktex option "-m");
-"   by default informational messages are shown as warnings
-"
-" - g:syntastic_tex_chktex_args (string; default: empty)
-"   command line options to pass to chktex
 
 if exists('g:loaded_syntastic_tex_chktex_checker')
     finish
 endif
 let g:loaded_syntastic_tex_chktex_checker = 1
 
-let s:save_cpo = &cpo
-set cpo&vim
-
 if !exists('g:syntastic_tex_chktex_showmsgs')
     let g:syntastic_tex_chktex_showmsgs = 1
 endif
+
+if !exists('g:syntastic_tex_chktex_sort')
+    let g:syntastic_tex_chktex_sort = 1
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
 
 function! SyntaxCheckers_tex_chktex_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'args_after': '-q -v1' })
@@ -45,14 +36,10 @@ function! SyntaxCheckers_tex_chktex_GetLocList() dict
         \ '%Z%p^,' .
         \ '%-G%.%#'
 
-    let loclist =  SyntasticMake({
+    return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'subtype': 'Style' })
-
-    call self.setWantSort(1)
-
-    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/text/atdtool.vim
+++ b/bundle/syntastic/syntax_checkers/text/atdtool.vim
@@ -15,6 +15,10 @@ if exists("g:loaded_syntastic_text_atdtool_checker")
 endif
 let g:loaded_syntastic_text_atdtool_checker = 1
 
+if !exists('g:syntastic_text_atdtool_sort')
+    let g:syntastic_text_atdtool_sort = 1
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 

--- a/bundle/syntastic/syntax_checkers/text/igor.vim
+++ b/bundle/syntastic/syntax_checkers/text/igor.vim
@@ -1,0 +1,25 @@
+"============================================================================
+"File:        igor.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_text_igor_checker')
+    finish
+endif
+let g:loaded_syntastic_text_igor_checker = 1
+
+runtime! syntax_checkers/docbk/*.vim
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'text',
+    \ 'name': 'igor',
+    \ 'redirect': 'docbk/igor'})
+
+" vim: set et sts=4 sw=4:

--- a/bundle/syntastic/syntax_checkers/typescript/tsc.vim
+++ b/bundle/syntastic/syntax_checkers/typescript/tsc.vim
@@ -9,6 +9,10 @@ if exists("g:loaded_syntastic_typescript_tsc_checker")
 endif
 let g:loaded_syntastic_typescript_tsc_checker = 1
 
+if !exists('g:syntastic_typescript_tsc_sort')
+    let g:syntastic_typescript_tsc_sort = 1
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -23,14 +27,10 @@ function! SyntaxCheckers_typescript_tsc_GetLocList() dict
         \ '%Eerror %m,' .
         \ '%C%\s%\+%m'
 
-    let loclist = SyntasticMake({
+    return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'defaults': {'bufnr': bufnr("")} })
-
-    call self.setWantSort(1)
-
-    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/typescript/tslint.vim
+++ b/bundle/syntastic/syntax_checkers/typescript/tslint.vim
@@ -9,6 +9,10 @@ if exists("g:loaded_syntastic_typescript_tslint_checker")
 endif
 let g:loaded_syntastic_typescript_tslint_checker = 1
 
+if !exists('g:syntastic_typescript_tslint_sort')
+    let g:syntastic_typescript_tslint_sort = 1
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -25,15 +29,11 @@ function! SyntaxCheckers_typescript_tslint_GetLocList() dict
     " (comment-format) ts/app.ts[12, 36]: comment must start with lowercase letter
     let errorformat = '%f[%l\, %c]: %m'
 
-    let loclist = SyntasticMake({
+    return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
         \ 'preprocess': 'tslint',
         \ 'returns': [0, 2] })
-
-    call self.setWantSort(1)
-
-    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/bundle/syntastic/syntax_checkers/vala/valac.vim
+++ b/bundle/syntastic/syntax_checkers/vala/valac.vim
@@ -2,23 +2,6 @@
 "File:        vala.vim
 "Description: Syntax checking plugin for syntastic.vim
 "Maintainer:  Konstantin Stepanov (me@kstep.me)
-"Notes:       Add special comment line into your vala file starting with
-"             "// modules: " and containing space delimited list of vala
-"             modules, used by the file, so this script can build correct
-"             --pkg arguments.
-"             Add another special comment line into your vala file starting
-"             with "// vapidirs: " followed by a space delimited list of
-"             the vapi directories so this script can build with the correct
-"             --vapidir arguments
-"             Alternatively you can set the g:syntastic_vala_modules array
-"             and/or the g:syntastic_vala_vapidirs array
-"             in your .vimrc or .lvimrc with localvimrc plugin
-"             (http://www.vim.org/scripts/script.php?script_id=441).
-"             Valac compiler is not the fastest thing in the world, so you
-"             may want to disable this plugin with
-"             let g:syntastic_vala_check_disabled = 1 command in your .vimrc or
-"             command line. Unlet this variable to set it to 0 to reenable
-"             this checker.
 "License:     This program is free software. It comes without any warranty,
 "             to the extent permitted by applicable law. You can redistribute
 "             it and/or modify it under the terms of the Do What The Fuck You
@@ -63,7 +46,7 @@ function! s:GetValaVapiDirs()
         elseif type(g:syntastic_vala_vapi_dirs) == type([])
             return copy(g:syntastic_vala_vapi_dirs)
         else
-            echoerr 'g:syntastic_vala_vapi_dirs must be either list or string: fallback to in file modules string'
+            echoerr 'g:syntastic_vala_vapi_dirs must be either a list, or a string: fallback to in-file modules string'
         endif
     endif
 

--- a/bundle/syntastic/syntax_checkers/verilog/verilator.vim
+++ b/bundle/syntastic/syntax_checkers/verilog/verilator.vim
@@ -20,7 +20,8 @@ function! SyntaxCheckers_verilog_verilator_IsAvailable() dict
     if !exists('g:syntastic_verilog_compiler')
         let g:syntastic_verilog_compiler = self.getExec()
     endif
-    return executable(expand(g:syntastic_verilog_compiler))
+    call self.log('g:syntastic_verilog_compiler =', g:syntastic_verilog_compiler)
+    return executable(expand(g:syntastic_verilog_compiler, 1))
 endfunction
 
 function! SyntaxCheckers_verilog_verilator_GetLocList() dict

--- a/bundle/syntastic/syntax_checkers/vim/vimlint.vim
+++ b/bundle/syntastic/syntax_checkers/vim/vimlint.vim
@@ -36,9 +36,11 @@ function! SyntaxCheckers_vim_vimlint_GetHighlightRegex(item)
 endfunction
 
 function! SyntaxCheckers_vim_vimlint_IsAvailable() dict
-    return
-        \ globpath(&runtimepath, 'autoload/vimlparser.vim') != '' &&
-        \ globpath(&runtimepath, 'autoload/vimlint.vim') != ''
+    let vimlparser = globpath(&runtimepath, 'autoload/vimlparser.vim', 1)
+    let vimlint    = globpath(&runtimepath, 'autoload/vimlint.vim', 1)
+    call self.log("globpath(&runtimepath, 'autoload/vimlparser.vim', 1) = " . string(vimlparser) . ', ' .
+                \ "globpath(&runtimepath, 'autoload/vimlint.vim', 1) = " .    string(vimlint))
+    return vimlparser != '' && vimlint != ''
 endfunction
 
 function! SyntaxCheckers_vim_vimlint_GetLocList() dict
@@ -72,7 +74,7 @@ function! SyntaxCheckers_vim_vimlint_GetLocList() dict
         endif
     endif
 
-    return vimlint#vimlint(expand('%'), param)
+    return vimlint#vimlint(expand('%', 1), param)
 endfunction
 
 " @vimlint(EVL103, 1, a:filename)

--- a/bundle/syntastic/syntax_checkers/xhtml/tidy.vim
+++ b/bundle/syntastic/syntax_checkers/xhtml/tidy.vim
@@ -29,7 +29,7 @@ set cpo&vim
 
 " TODO: join this with html.vim DRY's sake?
 function! s:TidyEncOptByFenc()
-    let tidy_opts = {
+    let TIDY_OPTS = {
             \ 'utf-8':        '-utf8',
             \ 'ascii':        '-ascii',
             \ 'latin1':       '-latin1',
@@ -43,12 +43,12 @@ function! s:TidyEncOptByFenc()
             \ 'sjis':         '-shiftjis',
             \ 'cp850':        '-ibm858',
         \ }
-    return get(tidy_opts, &fileencoding, '-utf8')
+    return get(TIDY_OPTS, &fileencoding, '-utf8')
 endfunction
 
 function! s:IgnoreError(text)
-    for i in g:syntastic_xhtml_tidy_ignore_errors
-        if stridx(a:text, i) != -1
+    for item in g:syntastic_xhtml_tidy_ignore_errors
+        if stridx(a:text, item) != -1
             return 1
         endif
     endfor

--- a/bundle/syntastic/syntax_checkers/yaml/jsyaml.vim
+++ b/bundle/syntastic/syntax_checkers/yaml/jsyaml.vim
@@ -8,9 +8,6 @@
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
-"
-"Installation: $ npm install -g js-yaml
-"
 "============================================================================
 
 if exists("g:loaded_syntastic_yaml_jsyaml_checker")
@@ -23,8 +20,9 @@ set cpo&vim
 
 function! SyntaxCheckers_yaml_jsyaml_GetLocList() dict
     if !exists('s:js_yaml_new')
-        let s:js_yaml_new =
-            \ syntastic#util#versionIsAtLeast(syntastic#util#getVersion(self.getExecEscaped() . ' --version'), [2])
+        let ver = syntastic#util#getVersion(self.getExecEscaped() . ' --version')
+        call self.log(self.getExec() . ' version =', ver)
+        let s:js_yaml_new = syntastic#util#versionIsAtLeast(ver, [2])
     endif
 
     let makeprg = self.makeprgBuild({ 'args_after': (s:js_yaml_new ? '' : '--compact') })

--- a/bundle/syntastic/syntax_checkers/yaml/yamlxs.vim
+++ b/bundle/syntastic/syntax_checkers/yaml/yamlxs.vim
@@ -7,7 +7,6 @@
 "             it and/or modify it under the terms of the Do What The Fuck You
 "             Want To Public License, Version 2, as published by Sam Hocevar.
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
-"Installation: cpanm YAML::XS
 "
 "============================================================================
 

--- a/bundle/syntastic/syntax_checkers/z80/z80syntaxchecker.vim
+++ b/bundle/syntastic/syntax_checkers/z80/z80syntaxchecker.vim
@@ -1,5 +1,5 @@
 "============================================================================
-"File:        z80.vim
+"File:        z80syntaxchecker.vim
 "Description: Syntax checking plugin for syntastic.vim
 "Maintainer:  Romain Giot <giot.romain at gmail dot com>
 "License:     This program is free software. It comes without any warranty,
@@ -9,12 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" To obtain this application there are two solutions:
-" - Install this python package:
-"   https://github.com/rgiot/pycpcdemotools
-" - Copy/paste this script in your search path:
-"   https://raw.githubusercontent.com/rgiot/pycpcdemotools/master/cpcdemotools/source_checker/z80_syntax_checker.py
 
 if exists("g:loaded_syntastic_z80_z80syntaxchecker_checker")
     finish

--- a/bundle/syntastic/syntax_checkers/zpt/zptlint.vim
+++ b/bundle/syntastic/syntax_checkers/zpt/zptlint.vim
@@ -9,15 +9,6 @@
 "             See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 "============================================================================
-"
-" In order for this plugin to be useful, you will need to set up the
-" zpt filetype in your vimrc
-"
-"    " set up zope page templates as the zpt filetype
-"    au BufNewFile,BufRead *.pt,*.cpt,*.zpt set filetype=zpt syntax=xml
-"
-" Then install the zptlint program, found on pypi:
-" http://pypi.python.org/pypi/zptlint
 
 if exists("g:loaded_syntastic_zpt_zptlint_checker")
     finish

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -2134,7 +2134,7 @@ Local customizations:
   warnings.
 - Use nicer error and warning symbols where Vim can support it.
 
-Version 2014-07-31 (c2e7bf29) from git://github.com/scrooloose/syntastic.git
+Version 2015-01-04 (c472ec1) from git://github.com/scrooloose/syntastic.git
 
 Installation:
 - Follow bundle installation instructions (|bundle_installation|).


### PR DESCRIPTION
This fixes an issue where wildignore was affecting calls to expand(),
glob(), and globpath() causing some checkers to fail in interesting ways
(javac, for example).