### PR TITLE
Update to v0.1.2 of markdown2ctags.

### DIFF
--- a/tool/markdown2ctags/markdown2ctags.py
+++ b/tool/markdown2ctags/markdown2ctags.py
@@ -10,7 +10,7 @@ import sys
 import re
 
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 class ScriptError(Exception):
@@ -100,8 +100,17 @@ settextSubjectRe = re.compile(r'^[^\s]+.*$')
 def findSections(filename, lines):
     sections = []
     previousSections = []
+    inCodeBlock = False
 
     for i, line in enumerate(lines):
+        # Skip GitHub Markdown style code blocks.
+        if line.startswith("```"):
+            inCodeBlock = not inCodeBlock
+            continue
+
+        if inCodeBlock:
+            continue
+
         m = atxHeadingRe.match(line)
         if m:
             level = len(m.group(1))


### PR DESCRIPTION
This fixes an issue where comments inside GitHub Flavored Markdown code
blocks would be seen as section headers.