### PR TITLE
Update rst2ctags to v0.1.4.

### DIFF
--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -2147,7 +2147,7 @@ Requires ctags.exe to be in the path.  Generally this comes with Linux
 distributions.  Compiled binaries may be found at
 http://ctags.sourceforge.net/
 
-Added support for reStructuredText using rst2ctags v0.1.2.  rst2ctags can be
+Added support for reStructuredText using rst2ctags v0.1.4.  rst2ctags can be
 found at https://github.com/jszakmeister/rst2ctags, and a copy has been
 embedded in $VIMFILES/tool/rst2ctags.
 

--- a/tool/rst2ctags/rst2ctags.py
+++ b/tool/rst2ctags/rst2ctags.py
@@ -10,7 +10,7 @@ import sys
 import re
 
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 
 class ScriptError(Exception):
@@ -54,9 +54,13 @@ class Tag(object):
         return '\t'.join(formattedFields)
 
     def __str__(self):
-        return '%s\t%s\t%s;"\t%s' % (
-                self.tagName, self.tagFile, self.tagAddress,
-                self._formatFields())
+        tag = '%s\t%s\t%s;"\t%s' % (
+            self.tagName, self.tagFile, self.tagAddress,
+            self._formatFields())
+        if isinstance(tag, unicode):
+            return tag.encode('utf-8')
+        else:
+            return tag
 
     def __cmp__(self, other):
         return cmp(str(self), str(other))
@@ -213,8 +217,18 @@ def main():
 
     for filename in args:
         f = open(filename, 'rb')
-        lines = f.read().splitlines()
+        buf = f.read()
+
+        try:
+            buf = buf.decode('utf-8')
+        except UnicodeDecodeError:
+            pass
+
+        lines = buf.splitlines()
+
         f.close()
+        del buf
+
         sections = findSections(filename, lines)
 
         genTagsFile(output, sectionsToTags(sections), sort=options.sort)


### PR DESCRIPTION
rst2ctags now works with headings that contain UTF-8 characters.