### PR TITLE
Set the filetype .coveragerc to cfg.

### DIFF
--- a/filetype.vim
+++ b/filetype.vim
@@ -25,6 +25,7 @@ augroup filetypedetect
     au BufNewFile,BufRead svn-prop*.tmp setfiletype svn
     au BufNewFile,BufRead leinrc setfiletype sh
     au BufNewFile,BufRead .pypirc setfiletype cfg
+    au BufNewFile,BufRead .coveragerc setfiletype cfg
 
     " Setup Git-related filetypes.
     au BufNewFile,BufRead *.git/MERGE_MSG setfiletype gitcommit


### PR DESCRIPTION
I use coverage a fair amount in Python projects, and this is nice to have.  I've had it for quite some time locally, but figured it was good to share. :-)