### PR TITLE
Removed "leftover" Enhanced Commentify files.

### DIFF
--- a/ftplugin/ocaml_enhcomm.vim
+++ b/ftplugin/ocaml_enhcomm.vim
@@ -1,1 +1,0 @@
-set commentstring=(*%s*)

--- a/ftplugin/php_enhcomm.vim
+++ b/ftplugin/php_enhcomm.vim
@@ -1,6 +1,0 @@
-"
-" Normal HTML text has no synID-name. So we have to specify this problem
-" case here. Note that you should not try to comment lines starting
-" with '<?'.
-"
-call EnhCommentifyFallback4Embedded('&ft == "php" && synFiletype == ""', "html")


### PR DESCRIPTION
Randomly started editing php files and was getting an error in ftplugin/php_enhcomm.vim.  A little digging showed that ftplugin/php_enhcomm.vim (actually the remaining files in ftplugin) were from the Enhanced Commentify plugin which is not included in vimfiles.

I confirmed removing these files addresses the php file error on startup.  I believe it is safe to delete the other file as well as I see ocaml mentioned in tcomment.