### PR TITLE
Update vim-togglecursor to v0.4.0.

### DIFF
--- a/bundle/togglecursor/doc/tags
+++ b/bundle/togglecursor/doc/tags
@@ -6,7 +6,9 @@ togglecursor-supported	togglecursor.txt	/*togglecursor-supported*
 togglecursor-tips	togglecursor.txt	/*togglecursor-tips*
 togglecursor.txt	togglecursor.txt	/*togglecursor.txt*
 togglecursor_default	togglecursor.txt	/*togglecursor_default*
+togglecursor_disable_neovim	togglecursor.txt	/*togglecursor_disable_neovim*
 togglecursor_disable_tmux	togglecursor.txt	/*togglecursor_disable_tmux*
+togglecursor_force	togglecursor.txt	/*togglecursor_force*
 togglecursor_insert	togglecursor.txt	/*togglecursor_insert*
 togglecursor_leave	togglecursor.txt	/*togglecursor_leave*
 togglecursor_replace	togglecursor.txt	/*togglecursor_replace*

--- a/bundle/togglecursor/doc/togglecursor.txt
+++ b/bundle/togglecursor/doc/togglecursor.txt
@@ -18,13 +18,14 @@ supported terminals.
 SUPPORTED TERMINALS                              *togglecursor-supported*
 
 Currently supported terminals are iTerm2 for the Mac (version 1.0.0.20130602
-beta or better is required) and KDE's Konsole.  The xterm console is partially
-supported as well.  Older xterm's didn't support the line cursor, so this plugin
-currently sets the cursor to underline instead.
+beta or better is required), VTE3 based terminals (including gnome-terminal),
+and KDE's Konsole. The xterm console is partially supported as well. Older 
+xterm's didn't support the line cursor, so this plugin currently sets the 
+cursor to underline instead.
 
-The gnome-terminal application doesn't support changing the cursor via escape
-sequences and is not supported.  On unsupported terminals, Vim's default
-behavior is left unaltered.
+Older versions of VTE3 based terminals (before v0.39) do not support changing 
+the cursor via escape sequences and are not supported.  On unsupported 
+terminals, Vim's default behavior is left unaltered.
 
 The plugin also supports tmux, and will change your cursor inside a tmux
 session too.
@@ -52,6 +53,13 @@ g:togglecursor_leave    The cursor shape to set when exiting Vim.  The default
 g:togglecursor_replace  The replace mode cursor shape.  The default value is
                         'underline'.
 
+                                                 *togglecursor_force*
+g:togglecursor_force    Force togglecursor to use a particular mechanism to
+                        change the cursor.  Setting this turns off automatic
+                        detection.  The only valid choices are 'xterm' (which
+                        uses the DESCCUSR escape sequence) and 'cursorshape'
+                        (what Konsole and iTerm uses).
+
                                                  *togglecursor_disable_tmux*
 
 In some versions of tmux, the passthrough handling appears to be slightly
@@ -67,6 +75,20 @@ The default value for |togglecursor_disable_tmux| is 0.
 
 Note: options should be overridden in your vimrc.  Changing them after Vim has
 loaded will have little or no effect.
+
+                                                 *togglecursor_disable_neovim*
+By default, togglecursor will detect the presence of Neovim and turn on
+NVIM_TUI_ENABLE_CURSOR_SHAPE environment variable for you.  If you don't want
+this behavior, you can add the following to your vimrc: >
+
+    let g:togglecursor_disable_neovim = 1
+<
+Note: if you've already defined NVIM_TUI_ENABLE_CURSOR_SHAPE to a non-empty
+value, then togglecursor will leave it alone.  Also, Neovim's environment
+variable detection can't tell the difference between an unset variable and
+an empty variable.  So togglecursor may enable cursor support even though you've
+attempted to opt-out of it.  Setting g:togglecursor_disable_neovim will keep
+togglecursor from attempting to set the NVIM_TUI_ENABLE_CURSOR_SHAPE variable.
 
 ==============================================================================
 LIMITATIONS                                      *togglecursor-limitations*
@@ -100,6 +122,16 @@ name and save them there.  The bug has been reported to Konsole, but it's
 unclear what they're going to do about it.  The bug was reported here:
 https://bugs.kde.org/show_bug.cgi?id=323227.
 
+Note: Neovim doesn't allow the technique used by togglecursor to work.  Neovim
+does natively have the ability to change cursor shape by the
+NVIM_TUI_ENABLE_CURSOR_SHAPE environment variable--though you cannot control
+the shapes.  The plugin will set this environment variable for you, but will not
+offer any control over the actual shapes.  In fact, it will look like the plugin
+hasn't loaded--the environment variable is set, and then the plugin exits.
+
+If you find that the Neovim's sequences are not working for your terminal, you
+can disable this feature using |togglecursor_disable_neovim|.
+
 ==============================================================================
 TIPS                                             *togglecursor-tips*
 
@@ -122,9 +154,9 @@ Now the TERM_PROGRAM environment variable will be passed to the remote session
 and togglecursor will be able to change the cursor correctly.
 
 You can configure Konsole to set TERM_PROGRAM by editing the environment in
-'Settings->Edit Current Profile->General' and adding the following line:
+'Settings->Edit Current Profile->General' and adding the following line: >
     TERM_PROGRAM=Konsole
-
+<
 ==============================================================================
 ABOUT                                            *togglecursor-about*
 

--- a/bundle/togglecursor/plugin/togglecursor.vim
+++ b/bundle/togglecursor/plugin/togglecursor.vim
@@ -2,13 +2,32 @@
 " File:         togglecursor.vim
 " Description:  Toggles cursor shape in the terminal
 " Maintainer:   John Szakmeister <john@szakmeister.net>
-" Version:      0.3.0
+" Version:      0.4.0
 " License:      Same license as Vim.
 " ============================================================================
 
 if exists('g:loaded_togglecursor') || &cp || !has("cursorshape")
   finish
 endif
+
+" Bail out early if not running under a terminal.
+if has("gui_running")
+    finish
+endif
+
+if !exists("g:togglecursor_disable_neovim")
+    let g:togglecursor_disable_neovim = 0
+endif
+
+if has("nvim")
+    " If Neovim support is enabled, then let set the
+    " NVIM_TUI_ENABLE_CURSOR_SHAPE for the user.
+    if $NVIM_TUI_ENABLE_CURSOR_SHAPE == "" && g:togglecursor_disable_neovim == 0
+        let $NVIM_TUI_ENABLE_CURSOR_SHAPE = 1
+    endif
+    finish
+endif
+
 let g:loaded_togglecursor = 1
 
 let s:cursorshape_underline = "\<Esc>]50;CursorShape=2;BlinkingCursorEnabled=0\x7"
@@ -33,16 +52,34 @@ let s:xterm_blinking_underline = "\<Esc>[3 q"
 let s:in_tmux = exists("$TMUX")
 
 let s:supported_terminal = ''
+let s:prefix_ti = 0
 
 " Check for supported terminals.
-if !has("gui_running")
+if exists("g:togglecursor_force") && g:togglecursor_force != ""
+    if count(["xterm", "cursorshape"], g:togglecursor_force) == 0
+        echoerr "Invalid value for g:togglecursor_force: " .
+                \ g:togglecursor_force
+    else
+        let s:supported_terminal = g:togglecursor_force
+    endif
+endif
+
+if s:supported_terminal == ""
     if $TERM_PROGRAM == "iTerm.app" || exists("$ITERM_SESSION_ID")
-                \ || $XTERM_VERSION != ""
-                " \ || $VTE_VERSION != ""
-        " iTerm, xterm, and future VTE based terminals support DESCCUSR.
+            \ || $XTERM_VERSION != ""
+            \ || str2nr($VTE_VERSION) >= 3900
+        " iTerm, xterm, and VTE based terminals support DESCCUSR.
         let s:supported_terminal = 'xterm'
     elseif $TERM_PROGRAM == "Konsole" || exists("$KONSOLE_DBUS_SESSION")
-        "cursorshape for konsole
+        " This detection is not perfect.  KONSOLE_DBUS_SESSION seems to show
+        " up in the environment despite running under tmux in an ssh
+        " session if you have also started a tmux session locally on target
+        " box under KDE.
+
+        " Prefix t_ti when we're under Konsole.  Having our escape come
+        " first seems to work better with tmux and konsole under Linux.
+        let s:prefix_ti = 1
+
         let s:supported_terminal = 'cursorshape'
     endif
 endif
@@ -136,9 +173,9 @@ function! s:ToggleCursorByMode()
     endif
 endfunction
 
-" Having our escape come first seems to work better with tmux and konsole under
-" Linux.
-let &t_ti = s:GetEscapeCode(g:togglecursor_default) . &t_ti
+if s:prefix_ti
+    let &t_ti = s:GetEscapeCode(g:togglecursor_default) . &t_ti
+endif
 
 augroup ToggleCursorStartup
     autocmd!


### PR DESCRIPTION
This improves the behavior of changing the cursor under gnome-terminal,
adds support for VTE-based terminals (v0.39 or better), allows users to
force a particular style of changing the cursor (useful for unsupported
terminals), and will now turn on the NVIM_TUI_ENABLE_CURSOR_SHAPE for
Neovim users.