### PR TITLE
Update to v0.5.0 of vim-togglecursor.

### DIFF
--- a/bundle/togglecursor/doc/tags
+++ b/bundle/togglecursor/doc/tags
@@ -2,11 +2,15 @@ togglecursor	togglecursor.txt	/*togglecursor*
 togglecursor-about	togglecursor.txt	/*togglecursor-about*
 togglecursor-limitations	togglecursor.txt	/*togglecursor-limitations*
 togglecursor-options	togglecursor.txt	/*togglecursor-options*
+togglecursor-sudo	togglecursor.txt	/*togglecursor-sudo*
 togglecursor-supported	togglecursor.txt	/*togglecursor-supported*
 togglecursor-tips	togglecursor.txt	/*togglecursor-tips*
 togglecursor.txt	togglecursor.txt	/*togglecursor.txt*
 togglecursor_default	togglecursor.txt	/*togglecursor_default*
+togglecursor_disable_default_init	togglecursor.txt	/*togglecursor_disable_default_init*
+togglecursor_disable_neovim	togglecursor.txt	/*togglecursor_disable_neovim*
 togglecursor_disable_tmux	togglecursor.txt	/*togglecursor_disable_tmux*
+togglecursor_force	togglecursor.txt	/*togglecursor_force*
 togglecursor_insert	togglecursor.txt	/*togglecursor_insert*
 togglecursor_leave	togglecursor.txt	/*togglecursor_leave*
 togglecursor_replace	togglecursor.txt	/*togglecursor_replace*

--- a/bundle/togglecursor/doc/togglecursor.txt
+++ b/bundle/togglecursor/doc/togglecursor.txt
@@ -18,13 +18,14 @@ supported terminals.
 SUPPORTED TERMINALS                              *togglecursor-supported*
 
 Currently supported terminals are iTerm2 for the Mac (version 1.0.0.20130602
-beta or better is required) and KDE's Konsole.  The xterm console is partially
-supported as well.  Older xterm's didn't support the line cursor, so this plugin
-currently sets the cursor to underline instead.
+beta or better is required), VTE3 based terminals (including gnome-terminal),
+and KDE's Konsole.  XTerm 252 or better is supported as well.  XTerms younger
+than 282 don't support the line cursor, so this plugin currently sets the cursor
+to an underline instead for insert mode.
 
-The gnome-terminal application doesn't support changing the cursor via escape
-sequences and is not supported.  On unsupported terminals, Vim's default
-behavior is left unaltered.
+Older versions of VTE3 based terminals (before v0.39) do not support changing 
+the cursor via escape sequences and are not supported.  On unsupported 
+terminals, Vim's default behavior is left unaltered.
 
 The plugin also supports tmux, and will change your cursor inside a tmux
 session too.
@@ -38,19 +39,32 @@ allowed to be one of 'block', 'blinking_block', 'line', 'blinking_line',
 
                                                  *togglecursor_default*
 g:togglecursor_default  The default cursor shape.  It is used in all modes
-                        except insert mode.  The default value is 'block'.
+                        except insert mode.  The default value is
+                        'blinking_block', where it's known to be supported,
+                        and 'block' otherwise.
 
                                                  *togglecursor_insert*
 g:togglecursor_insert   The insert mode cursor shape.  The default value is
-                        'line'.
+                        'blinking_line' where supported, 'line' if the vertical
+                        line cursor is supported, or 'blinking_underline' if
+                        neither is supported.
 
                                                  *togglecursor_leave*
 g:togglecursor_leave    The cursor shape to set when exiting Vim.  The default
-                        value is to be the same a |togglecursor_default|.
+                        value is 'block', except on VTE-based terminals which
+                        commonly have blinking cursor and defaults to
+                        'blinking_block'.
 
                                                  *togglecursor_replace*
 g:togglecursor_replace  The replace mode cursor shape.  The default value is
                         'underline'.
+
+                                                 *togglecursor_force*
+g:togglecursor_force    Force togglecursor to use a particular mechanism to
+                        change the cursor.  Setting this turns off automatic
+                        detection.  The only valid choices are 'xterm' (which
+                        uses the DESCCUSR escape sequence) and 'cursorshape'
+                        (what Konsole uses).
 
                                                  *togglecursor_disable_tmux*
 
@@ -68,6 +82,35 @@ The default value for |togglecursor_disable_tmux| is 0.
 Note: options should be overridden in your vimrc.  Changing them after Vim has
 loaded will have little or no effect.
 
+                                                 *togglecursor_disable_neovim*
+By default, togglecursor will detect the presence of Neovim and turn on
+NVIM_TUI_ENABLE_CURSOR_SHAPE environment variable for you.  If you don't want
+this behavior, you can add the following to your vimrc: >
+
+    let g:togglecursor_disable_neovim = 1
+<
+Note: if you've already defined NVIM_TUI_ENABLE_CURSOR_SHAPE to a non-empty
+value, then togglecursor will leave it alone.  Also, Neovim's environment
+variable detection can't tell the difference between an unset variable and
+an empty variable.  So togglecursor may enable cursor support even though you've
+attempted to opt-out of it.  Setting g:togglecursor_disable_neovim will keep
+togglecursor from attempting to set the NVIM_TUI_ENABLE_CURSOR_SHAPE variable.
+
+                                             *togglecursor_disable_default_init*
+To support changing the normal mode cursor, togglecursor modifies 't_ti' to
+include an escape sequence to modify the cursor.  It has been seen on VTE
+0.40.2-based terminals that this can cause the cursor to disappear.
+
+To allow users to workaround this kind of bug, you can set
+g:togglecursor_disable_default_init to a non-zero value in your vimrc: >
+
+    let g:togglecursor_disable_default_init = 1
+<
+This will prevent togglecursor from altering 't_ti' at the cost of not having
+the correct cursor when first entering Vim.  Once you go into insert mode and
+back to normal mode, you'll find that the cursor has changed to the desired
+type.
+
 ==============================================================================
 LIMITATIONS                                      *togglecursor-limitations*
 
@@ -75,9 +118,9 @@ Since this plugin relies on detecting on the type of terminal being run, it
 will not work automatically when working remotely.  The required environment
 variables are simply not available.
 
-This also doesn't support all terminals.  Currently, only iTerm2 for the Mac,
-and Konsole under Linux are supported.  Others may be added later, as long as
-there is a safe way to detect and add that support.
+This also doesn't support all terminals, see |togglecursor-supported| for
+details.  Others may be added later, as long as there is a safe way to detect
+and add that support.
 
 Also, this plugin works by setting the |t_SI|, |t_EI|, |t_ti|, and |t_te|
 options and including special escape codes to let the terminal know how to
@@ -100,6 +143,20 @@ name and save them there.  The bug has been reported to Konsole, but it's
 unclear what they're going to do about it.  The bug was reported here:
 https://bugs.kde.org/show_bug.cgi?id=323227.
 
+Note: Neovim doesn't allow the technique used by togglecursor to work.  Neovim
+does natively have the ability to change cursor shape by the
+NVIM_TUI_ENABLE_CURSOR_SHAPE environment variable--though you cannot control
+the shapes.  The plugin will set this environment variable for you, but will not
+offer any control over the actual shapes.  In fact, it will look like the plugin
+hasn't loaded--the environment variable is set, and then the plugin exits.
+
+If you find that the Neovim's sequences are not working for your terminal, you
+can disable this feature using |togglecursor_disable_neovim|.
+
+There has been a report of the cursor going missing on start-up with VTE
+0.40.2-based terminals.  If you're seeing this issue, take a look at
+|togglecursor_disable_default_init|.  Note: the issue was fixed in VTE 0.41.90.
+
 ==============================================================================
 TIPS                                             *togglecursor-tips*
 
@@ -111,19 +168,40 @@ client configuration.
 
 The typical unix location for your ssh client configuration is in ~/.ssh/config.
 Simply add the following line to the file: >
+
     SendEnv TERM_PROGRAM
 <
 On the server side, the configuration is typically in /etc/ssh/sshd_config.  Add
 TERM_PROGRAM to the list of accepted environment variables.  It should look
 something like this: >
+
     AcceptEnv LANG LC_* TERM_PROGRAM
 <
 Now the TERM_PROGRAM environment variable will be passed to the remote session
 and togglecursor will be able to change the cursor correctly.
 
 You can configure Konsole to set TERM_PROGRAM by editing the environment in
-'Settings->Edit Current Profile->General' and adding the following line:
+'Settings->Edit Current Profile->General' and adding the following line: >
+
     TERM_PROGRAM=Konsole
+<
+==============================================================================
+SUDO                                            *togglecursor-sudo*
+
+The sudo tool scrubs the environment by default, preventing most environment
+variables from being forwarded into the new sudo environment, which prevents
+togglecursor from being able to detect the running terminal.  To allow
+auto-detection, you need to tell sudo to keep these environment
+variables.  This is done by using visudo to modify /etc/sudoers and add
+something like the following to file: >
+
+    Defaults env_keep += "TERM_PROGRAM VTE_VERSION XTERM_VERSION"
+<
+The exact variables to add depend on what you use.  For instance, if you use
+Konsole, you may need to add KONSOLE_DBUS_SESSION to the list.
+
+Another alternative is to set |togglecursor_force| to the correct value for the
+terminal you use and skip autodetection.
 
 ==============================================================================
 ABOUT                                            *togglecursor-about*

--- a/bundle/togglecursor/plugin/togglecursor.vim
+++ b/bundle/togglecursor/plugin/togglecursor.vim
@@ -2,13 +2,36 @@
 " File:         togglecursor.vim
 " Description:  Toggles cursor shape in the terminal
 " Maintainer:   John Szakmeister <john@szakmeister.net>
-" Version:      0.3.0
+" Version:      0.5.0
 " License:      Same license as Vim.
 " ============================================================================
 
 if exists('g:loaded_togglecursor') || &cp || !has("cursorshape")
   finish
 endif
+
+" Bail out early if not running under a terminal.
+if has("gui_running")
+    finish
+endif
+
+if !exists("g:togglecursor_disable_neovim")
+    let g:togglecursor_disable_neovim = 0
+endif
+
+if !exists("g:togglecursor_disable_default_init")
+    let g:togglecursor_disable_default_init = 0
+endif
+
+if has("nvim")
+    " If Neovim support is enabled, then let set the
+    " NVIM_TUI_ENABLE_CURSOR_SHAPE for the user.
+    if $NVIM_TUI_ENABLE_CURSOR_SHAPE == "" && g:togglecursor_disable_neovim == 0
+        let $NVIM_TUI_ENABLE_CURSOR_SHAPE = 1
+    endif
+    finish
+endif
+
 let g:loaded_togglecursor = 1
 
 let s:cursorshape_underline = "\<Esc>]50;CursorShape=2;BlinkingCursorEnabled=0\x7"
@@ -35,16 +58,40 @@ let s:in_tmux = exists("$TMUX")
 let s:supported_terminal = ''
 
 " Check for supported terminals.
-if !has("gui_running")
+if exists("g:togglecursor_force") && g:togglecursor_force != ""
+    if count(["xterm", "cursorshape"], g:togglecursor_force) == 0
+        echoerr "Invalid value for g:togglecursor_force: " .
+                \ g:togglecursor_force
+    else
+        let s:supported_terminal = g:togglecursor_force
+    endif
+endif
+
+function! s:GetXtermVersion(version)
+    return str2nr(matchstr(a:version, '\v^XTerm\(\zs\d+\ze\)'))
+endfunction
+
+if s:supported_terminal == ""
+    " iTerm, xterm, and VTE based terminals support DESCCUSR.
     if $TERM_PROGRAM == "iTerm.app" || exists("$ITERM_SESSION_ID")
-                \ || $XTERM_VERSION != ""
-                " \ || $VTE_VERSION != ""
-        " iTerm, xterm, and future VTE based terminals support DESCCUSR.
+        let s:supported_terminal = 'xterm'
+    elseif str2nr($VTE_VERSION) >= 3900
+        let s:supported_terminal = 'xterm'
+    elseif s:GetXtermVersion($XTERM_VERSION) >= 252
         let s:supported_terminal = 'xterm'
     elseif $TERM_PROGRAM == "Konsole" || exists("$KONSOLE_DBUS_SESSION")
-        "cursorshape for konsole
+        " This detection is not perfect.  KONSOLE_DBUS_SESSION seems to show
+        " up in the environment despite running under tmux in an ssh
+        " session if you have also started a tmux session locally on target
+        " box under KDE.
+
         let s:supported_terminal = 'cursorshape'
     endif
+endif
+
+if s:supported_terminal == ''
+    " The terminal is not supported, so bail.
+    finish
 endif
 
 
@@ -53,26 +100,26 @@ endif
 " -------------------------------------------------------------
 
 if !exists("g:togglecursor_default")
-    let g:togglecursor_default = 'block'
+    let g:togglecursor_default = 'blinking_block'
 endif
 
 if !exists("g:togglecursor_insert")
-    let g:togglecursor_insert = 'line'
-    if exists("$XTERM_VERSION")
-        let xterm_patch = str2nr(matchstr($XTERM_VERSION,
-                    \ '\v^XTerm\(\zs\d+\ze\)'))
-        if xterm_patch < 282
-            let g:togglecursor_insert = 'underline'
-        endif
+    let g:togglecursor_insert = 'blinking_line'
+    if $XTERM_VERSION != "" && s:GetXtermVersion($XTERM_VERSION) < 282
+        let g:togglecursor_insert = 'blinking_underline'
     endif
 endif
 
 if !exists("g:togglecursor_replace")
-    let g:togglecursor_replace = 'underline'
+    let g:togglecursor_replace = 'blinking_underline'
 endif
 
 if !exists("g:togglecursor_leave")
-    let g:togglecursor_leave = g:togglecursor_default
+    if str2nr($VTE_VERSION) >= 3900
+        let g:togglecursor_leave = 'blinking_block'
+    else
+        let g:togglecursor_leave = 'block'
+    endif
 endif
 
 if !exists("g:togglecursor_disable_tmux")
@@ -136,9 +183,14 @@ function! s:ToggleCursorByMode()
     endif
 endfunction
 
-" Having our escape come first seems to work better with tmux and konsole under
-" Linux.
-let &t_ti = s:GetEscapeCode(g:togglecursor_default) . &t_ti
+" Setting t_ti allows us to get the cursor correct for normal mode when we first
+" enter Vim.  Having our escape come first seems to work better with tmux and
+" Konsole under Linux.  Allow users to turn this off, since some users of VTE
+" 0.40.2-based terminals seem to have issues with the cursor disappearing in the
+" certain environments.
+if g:togglecursor_disable_default_init == 0
+    let &t_ti = s:GetEscapeCode(g:togglecursor_default) . &t_ti
+endif
 
 augroup ToggleCursorStartup
     autocmd!

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -2502,7 +2502,7 @@ Xterm is partially supported as well (it will use an underline versus a line
 cursor by default).  This technique also works with tmux, although you may
 need version 1.7 or better.
 
-Version 0.1.1 (a97b8bed) from
+Version 0.5.0 (79b6ad85) from
 git://github.com/jszakmeister/vim-togglecursor.git
 
 Installation:


### PR DESCRIPTION
This adds support for enabling cursor changing under Neovim, VTE3 support, along with better XTerm support.  It also allows you to force the particular kind of escape sequence used, if your terminal is not automatically detected.

Note: the new versios does change the default cursors to be blinking to better match gvim's behavior.