### PR TITLE
Fix a powerline bug where symbols would disappear from the dictionary.

### DIFF
--- a/bundle/powerline/autoload/Pl/Parser.vim
+++ b/bundle/powerline/autoload/Pl/Parser.vim
@@ -79,6 +79,10 @@ function! Pl#Parser#ParseChars(arg) " {{{
 	let arg = a:arg
 
 	if type(arg) == type([])
+		" Retain our own copy of the list.  Otherwise, the original
+		" list might get stomped on.
+		let arg = copy(arg)
+
 		" Hex array
 		call map(arg, 'nr2char(v:val)')
 

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -1721,6 +1721,26 @@ If you don't want to use Powerline, you can add the following to your
 
     let g:EnablePowerline = 0
 <
+
+Powerline requires a patch to fix a bug where symbols in the symbol dictionary
+could get clobbered with empty results.  This fixes the issue by creating a
+copy of the original list:
+
+diff --git a/bundle/powerline/autoload/Pl/Parser.vim b/bundle/powerline/autoload/Pl/Parser.vim
+index a6f3428..3c91f56 100644
+--- a/bundle/powerline/autoload/Pl/Parser.vim
++++ b/bundle/powerline/autoload/Pl/Parser.vim
+@@ -79,6 +79,10 @@ function! Pl#Parser#ParseChars(arg) " {{{
+        let arg = a:arg
+
+        if type(arg) == type([])
++               " Retain our own copy of the list.  Otherwise, the original
++               " list might get stomped on.
++               let arg = copy(arg)
++
+                " Hex array
+                call map(arg, 'nr2char(v:val)')
+
 Version 2012-08-17 from https://github.com/Lokaltog/vim-powerline
 
 Installation:

--- a/vimrc
+++ b/vimrc
@@ -3279,7 +3279,7 @@ endif
 "   :2013-11-11.1
 " This vimfiles-wide setting will be appended to whatever value may have been
 " set via a |VIMRC_BEFORE| file.
-let g:PowerlineRequiredCacheTag .= ":2013-11-14"
+let g:PowerlineRequiredCacheTag .= ":2015-09-11"
 
 " This file records the current Powerline "tag".
 let g:PowerlineCacheTagFile = expand('$VIM_CACHE_DIR/PowerlineCacheTag')


### PR DESCRIPTION
While trying to work on a replacement fileinfo segment that does not use
a bolded LN symbol (to make it work better with the Hack typeface), I
noticed that the BRANCH and LINE symbols would eventually become [''].
It's still not entirely clear why this is happening, but it smells like
something is mutating a reference.  As a result, let's create a copy of
the arg in Pl#Parser#ParseChars() and return that instead.  This fix
allows everything to work correctly again.