### PR TITLE
Set `loaded_airline` to disable airline

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -2823,7 +2823,7 @@ let g:airline_mode_map = {
       \ }
 else
     " Airline will not load if this variable is defined:
-    let g:Airline_loaded = 1
+    let g:loaded_airline = 1
 endif
 
 


### PR DESCRIPTION
In the logic to disable airline, `g:Airline_loaded` is set in an
attempt to prevent the plugin from loading which was not working as
expected.  Looking through the plugin, loading is controlled via
`g:loaded_airline`.  This request updates the logic to set the
appropriate variable to prevent airline from loading.