### PR TITLE
Update rst2ctags to v0.1.5.

### DIFF
--- a/tool/rst2ctags/rst2ctags.py
+++ b/tool/rst2ctags/rst2ctags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013 John Szakmeister <john@szakmeister.net>
 # All rights reserved.
@@ -10,7 +10,7 @@ import sys
 import re
 
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 
 class ScriptError(Exception):
@@ -99,7 +99,7 @@ class Section(object):
         return '<Section %s %d %d>' % (self.name, self.level, self.lineNumber)
 
 
-headingRe = re.compile(r'''^[-=~:^"#*._+`']+$''')
+headingRe = re.compile(r'''^([-=~:^"#*._+`'])\1+$''')
 subjectRe = re.compile(r'^[^\s]+.*$')
 
 def findSections(filename, lines):


### PR DESCRIPTION
This version changes the shebang line to use python2, and ensures the
heading characters are homogeneous.