### PR TITLE
Make IsQuickFixWin() work correctly in newer versions of Vim.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1056,12 +1056,27 @@ function! IsQuickFixWin()
         " then this will succeed and the focus will stay on this window.
         " If this is a QuickFix window, there will be an exception and the
         " focus will stay on this window.
-        try
-            noautocmd lopen
-        catch /E776:/
-            " This was a QuickFix window.
-            return 1
-        endtry
+        "
+        " Unfortunately, the above technique broke with newer versions of Vim
+        " ls lopen was considered to be editing the buffer.  Instead, we'll use
+        " the new win_getid() to grab the window id and then use that to check
+        " the window information to see if it's a quickfix window (it does
+        " distinguish between quickfix and loclist).
+        if exists('*win_getid')
+            let info = getwininfo(win_getid())
+            if len(info) && info[0]['quickfix']
+                return 1
+            else
+                return 0
+            endif
+        else
+            try
+                noautocmd lopen
+            catch /E776:/
+                " This was a QuickFix window.
+                return 1
+            endtry
+        endif
     endif
     return 0
 endfunction


### PR DESCRIPTION
At some point in Vim 8.0 they stopped allowing the :lopen command from
being called inside an autocmd.  Unfortunately, this causes an error
trace and it doesn't fail in a way that allows us to distinguish the
type of window it is either.  However, a new built-in was added to allow
us to get the window id and look up whether it's a quickfix or loclist.
So we'll prefer that technique when available, and when it isn't we fall
back to the old technique.  win_getid() first appeared in 7.4.2063, so
there should not be any gaps where both techniques may fail.