### PR TITLE
Upgrade vim-togglecursor to 0.5.2.

### DIFF
--- a/bundle/togglecursor/plugin/togglecursor.vim
+++ b/bundle/togglecursor/plugin/togglecursor.vim
@@ -2,7 +2,7 @@
 " File:         togglecursor.vim
 " Description:  Toggles cursor shape in the terminal
 " Maintainer:   John Szakmeister <john@szakmeister.net>
-" Version:      0.5.1
+" Version:      0.5.2
 " License:      Same license as Vim.
 " ============================================================================
 
@@ -54,6 +54,10 @@ let s:xterm_blinking_line = "\<Esc>[5 q"
 let s:xterm_blinking_underline = "\<Esc>[3 q"
 
 let s:in_tmux = exists("$TMUX")
+
+" Detect whether this version of vim supports changing the replace cursor
+" natively.
+let s:sr_supported = exists("+t_SR")
 
 let s:supported_terminal = ''
 
@@ -169,6 +173,9 @@ function! s:ToggleCursorInit()
 
     let &t_EI = s:GetEscapeCode(g:togglecursor_default)
     let &t_SI = s:GetEscapeCode(g:togglecursor_insert)
+    if s:sr_supported
+        let &t_SR = s:GetEscapeCode(g:togglecursor_replace)
+    endif
 endfunction
 
 function! s:ToggleCursorLeave()
@@ -200,5 +207,7 @@ augroup ToggleCursorStartup
     autocmd!
     autocmd VimEnter * call <SID>ToggleCursorInit()
     autocmd VimLeave * call <SID>ToggleCursorLeave()
-    autocmd InsertEnter * call <SID>ToggleCursorByMode()
+    if !s:sr_supported
+        autocmd InsertEnter * call <SID>ToggleCursorByMode()
+    endif
 augroup END

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -2714,7 +2714,7 @@ Xterm is partially supported as well (it will use an underline versus a line
 cursor by default).  This technique also works with tmux, although you may
 need version 1.7 or better.
 
-Version 0.5.1 (8e88f926) from:
+Version 0.5.2 (a8dd2408) from:
 https://github.com/jszakmeister/vim-togglecursor.git
 
 Installation:


### PR DESCRIPTION
It now avoids some extra work when Vim supports the t_SR option.