### PR TITLE
Guard the ale settings since we make use of some ale functions.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -3337,15 +3337,17 @@ endif
 " ALE
 " -------------------------------------------------------------
 
-let g:ale_sign_column_always = 1
+if exists('g:loaded_ale') && g:loaded_ale
+    let g:ale_sign_column_always = 1
 
-" Pylint is too picky to be on by default.
-let g:ale_linters_ignore = { 'python': ['pylint'] }
+    " Pylint is too picky to be on by default.
+    let g:ale_linters_ignore = { 'python': ['pylint'] }
 
-" Experiment with disabling the extra-picky info messages out of rstcheck.
-let g:ale_rst_rstcheck_options =
-        \ '--ignore-messages ' . ale#Escape(
-        \ 'Duplicate implicit target name:')
+    " Experiment with disabling the extra-picky info messages out of rstcheck.
+    let g:ale_rst_rstcheck_options =
+            \ '--ignore-messages ' . ale#Escape(
+            \ 'Duplicate implicit target name:')
+endif
 
 " -------------------------------------------------------------
 " BufExplorer


### PR DESCRIPTION
If you don't have ale enabled, then you end up with an ugly error
message:

    Error detected while processing /Users/jszakmeister/.vim/vimrc:
    line 3348:
    E117: Unknown function: ale#Escape
    E15: Invalid expression: '--ignore-messages ' . ale#Escape( 'Duplicate implicit target name:')

This happens because ale is not loaded by default (since we're
experimenting with it) and `ale#Escape` is not defined.