### PR TITLE
Support .ini syntax in Markdown files.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -5779,6 +5779,9 @@ function! SetupMarkdownSyntax()
             " have both C and CPP active at the same time.  Map C highlighting
             " to CPP to avoid this problem.
             let synLang = "cpp"
+        elseif lang == "ini"
+            " The Vim filetype for .ini files is 'dosini'.
+            let synLang = "dosini"
         endif
 
         let synGroup = "markdownHighlight" . synLang


### PR DESCRIPTION
We base our Markdown embedded languages on the reStructuredText ones by
default, so we need to same ini mapping done in reStructuedText when
setting up ini syntax support in Markdown.