### PR TITLE
Only set termguicolors if Vim supports the feature.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -546,7 +546,9 @@ call pathogen#infect('pre-bundle/{}')
 " Enable 24-bit color for terminals that support it.
 " To countermand this, put ``set notermguicolors`` in your vimrc-before file.
 if $COLORTERM == 'truecolor'
-    set termguicolors
+    if has("termguicolors")
+        set termguicolors
+    endif
     if $TERM =~ 'screen'
         let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
         let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"


### PR DESCRIPTION
Ran into this issue on a VM with an old version of Vim. :-)