### PR TITLE
Upgrade rst2ctags and markdown2ctags.

### DIFF
--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -2479,11 +2479,11 @@ Local customizations:
   CTRL-q T      - toggle the tagbar (:TagbarToggle)
   <Space> q t   - toggle the tagbar (:TagbarToggle)
 
-Added support for reStructuredText using rst2ctags v0.2.5.  rst2ctags can be
+Added support for reStructuredText using rst2ctags v0.2.6.  rst2ctags can be
 found at https://github.com/jszakmeister/rst2ctags, and a copy has been
 embedded in $VIMFILES/tool/rst2ctags.
 
-Also added support for markdown using markdown2ctags v0.3.2.  markdown2ctags
+Also added support for markdown using markdown2ctags v0.3.3.  markdown2ctags
 can be found at https://github.com/jszakmeister/markdown2ctags, and a copy has
 been embedded in $VIMFILES/tool/markdown2ctags.
 

--- a/tool/markdown2ctags/markdown2ctags.py
+++ b/tool/markdown2ctags/markdown2ctags.py
@@ -13,20 +13,11 @@ import codecs
 import errno
 import io
 import locale
-import pkg_resources
 import sys
 import re
 
 
-def _version():
-    '''Get version.'''
-    try:
-        return pkg_resources.get_distribution('markdown2ctags').version
-    except pkg_resources.DistributionNotFound:
-        return 'dev'
-
-
-__version__ = _version()
+__version__ = "0.3.3"
 
 
 class ScriptError(Exception):

--- a/tool/rst2ctags/rst2ctags.py
+++ b/tool/rst2ctags/rst2ctags.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2013-2018 John Szakmeister <john@szakmeister.net>
+# Copyright (C) 2013-2020 John Szakmeister <john@szakmeister.net>
 # All rights reserved.
 #
 # This software is licensed as described in the file LICENSE.txt, which
@@ -13,20 +13,11 @@ import codecs
 import errno
 import io
 import locale
-import pkg_resources
 import sys
 import re
 
 
-def _version():
-    '''Get version.'''
-    try:
-        return pkg_resources.get_distribution('rst2ctags').version
-    except pkg_resources.DistributionNotFound:
-        return 'dev'
-
-
-__version__ = _version()
+__version__ = "0.2.6"
 
 
 class ScriptError(Exception):


### PR DESCRIPTION
This version doesn't use pkg_resources anymore, saving us on start up
time.