### PR TITLE
Allow vimfiles to work with native macOS vim diffopt

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,12 @@ Significant changes to vimfiles (newest changes first).
 Changes marked with "BREAKING CHANGE" indicate an incompatible change that may
 require adjustment of per-user settings.
 
+2021-11-02
+==========
+
+- Fix diffopt errors when using native macOS vim, see
+  https://github.com/thoughtbot/dotfiles/issues/655
+
 2021-10-19
 ==========
 

--- a/vimrc
+++ b/vimrc
@@ -985,10 +985,22 @@ set updatetime=1000
 " Disallow octal numbers for increment/decrement (CTRL-a/CTRL-x).
 set nrformats-=octal
 
-" Perform vertically split diffs by default.
-set diffopt+=vertical
+function! HasInternalDiff()
+    let parts = split(&diffopt, ',')
+    let using_internal = (count(parts, 'internal') == 1)
+    try
+        set diffopt+=internal
+        if !using_internal
+            set diffopt-=internal
+        endif
+        return 1
+    catch /E474:/
+        set diffopt-=internal
+        return 0
+    endtry
+endfunction
 
-if v:version > 801 || (v:version == 801 && has('patch-8.1.0360'))
+if HasInternalDiff()
     " Use the new internal diff feature with options:
     " - indent-heuristic: uses indentation to improve diffs.
     " - algorithm:histogram: an improved patience algorithm as used in Git.
@@ -996,6 +1008,9 @@ if v:version > 801 || (v:version == 801 && has('patch-8.1.0360'))
     set diffopt+=indent-heuristic
     set diffopt+=algorithm:histogram
 endif
+
+" Perform vertically split diffs by default.
+set diffopt+=vertical
 
 " Unfortunately, do to some redirection that Vim uses underneath the hood, it
 " can hide an error status of a command.  This helps to preserve the error


### PR DESCRIPTION
Tested on MacOS BigSur and Catalina.  Also, tested on Ubuntu 20.04 with custom built (`buildtool`) vim:
```
$ vim --version
VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Feb  5 2021 16:21:06)
Included patches: 1-2467
Compiled by vim@drmikehenry.com
Huge version without GUI.  Features included (+) or not (-):
+acl               -farsi             +mouse_sgr         +tag_binary
+arabic            +file_in_path      -mouse_sysmouse    -tag_old_static
+autocmd           +find_in_path      +mouse_urxvt       -tag_any_white
+autochdir         +float             +mouse_xterm       +tcl
-autoservername    +folding           +multi_byte        +termguicolors
-balloon_eval      -footer            +multi_lang        +terminal
+balloon_eval_term +fork()            -mzscheme          +terminfo
-browse            +gettext           +netbeans_intg     +termresponse
++builtin_terms    -hangul_input      +num64             +textobjects
+byte_offset       +iconv             +packages          +textprop
+channel           +insert_expand     +path_extra        +timers
+cindent           +ipv6              +perl              +title
-clientserver      +job               +persistent_undo   -toolbar
-clipboard         +jumplist          +popupwin          +user_commands
+cmdline_compl     +keymap            +postscript        +vartabs
+cmdline_hist      +lambda            +printer           +vertsplit
+cmdline_info      +langmap           +profile           +virtualedit
+comments          +libcall           +python            +visual
+conceal           +linebreak         -python3           +visualextra
+cryptv            +lispindent        +quickfix          +viminfo
+cscope            +listcmds          +reltime           +vreplace
+cursorbind        +localmap          +rightleft         +wildignore
+cursorshape       -lua               +ruby              +wildmenu
+dialog_con        +menu              +scrollbind        +windows
+diff              +mksession         +signs             +writebackup
+digraphs          +modify_fname      +smartindent       -X11
-dnd               +mouse             -sound             -xfontset
-ebcdic            -mouseshape        +spell             -xim
+emacs_tags        +mouse_dec         +startuptime       -xpm
+eval              +mouse_gpm         +statusline        -xsmp
+ex_extra          -mouse_jsbterm     -sun_workshop      -xterm_clipboard
+extra_search      +mouse_netterm     +syntax            -xterm_save
   system vimrc file: "$VIM/vimrc"
     user vimrc file: "$HOME/.vimrc"
 2nd user vimrc file: "~/.vim/vimrc"
      user exrc file: "$HOME/.exrc"
       defaults file: "$VIMRUNTIME/defaults.vim"
  fall-back for $VIM: "/usr/local/share/vim"
Compilation: gcc -c -I. -Iproto -DHAVE_CONFIG_H -g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 
Linking: gcc -L. -fstack-protector-strong -rdynamic -Wl,-export-dynamic -L/home/linuxbrew/.linuxbrew/opt/libyaml/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libyaml/lib -L/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib -L/home/linuxbrew/.linuxbrew/opt/readline/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/readline/lib -Wl,-E -Wl,-rpath,/home/linuxbrew/.linuxbrew/Cellar/perl/5.32.1/lib/perl5/5.32.1/x86_64-linux-thread-multi/CORE -L/usr/local/lib -Wl,--as-needed -o vim -lm -ltinfo -lgpm -ldl -Wl,-E -Wl,-rpath,/home/linuxbrew/.linuxbrew/Cellar/perl/5.32.1/lib/perl5/5.32.1/x86_64-linux-thread-multi/CORE -fstack-protector-strong -L/usr/local/lib -L/home/linuxbrew/.linuxbrew/Cellar/perl/5.32.1/lib/perl5/5.32.1/x86_64-linux-thread-multi/CORE -lperl -lpthread -lnsl -ldl -lm -lcrypt -lutil -lc -L/usr/lib/python2.7/config-x86_64-linux-gnu -lpython2.7 -lpthread -ldl -lutil -lm -Xlinker -export-dynamic -Wl,-O1 -Wl,-Bsymbolic-functions -L/home/linuxbrew/.linuxbrew/Cellar/tcl-tk/8.6.11/lib -ltcl8.6 -ldl -lz -lpthread -lm -Wl,-rpath,/home/linuxbrew/.linuxbrew/Cellar/ruby/3.0.0_1/lib -L/home/linuxbrew/.linuxbrew/Cellar/ruby/3.0.0_1/lib -lruby -lm 
```